### PR TITLE
Catch errors when reseting a database

### DIFF
--- a/lib/app/settings/backup_settings_page.dart
+++ b/lib/app/settings/backup_settings_page.dart
@@ -44,6 +44,7 @@ class BackupSettings extends StatelessWidget {
                                   SnackBar(
                                       content: Text(t.backup.import.cancelled)),
                                 );
+
                                 return;
                               }
 
@@ -59,6 +60,8 @@ class BackupSettings extends StatelessWidget {
                                     content: Text(t.backup.import.success)),
                               );
                             }).catchError((err) {
+                              Navigator.pop(context);
+
                               ScaffoldMessenger.of(context).showSnackBar(
                                   SnackBar(content: Text(err.toString())));
                             });


### PR DESCRIPTION
Previously, when trying to reset the application's database from the settings, if the user selected an invalid file the application would crash. With this change this is much less likely to happen.

If an invalid file is detected, the previous version of the database will be returned.