### PR TITLE
Equal indicator in the trending numbers

### DIFF
--- a/lib/core/presentation/widgets/number_ui_formatters/ui_number_formatter.dart
+++ b/lib/core/presentation/widgets/number_ui_formatters/ui_number_formatter.dart
@@ -92,7 +92,7 @@ class UINumberFormatter {
             style: decimalsStyle ??
                 textStyle.copyWith(
                   fontWeight: FontWeight.w300,
-                  fontSize: max(valueFontSize * 0.75, 14),
+                  fontSize: max(valueFontSize * 0.75, 12.25),
                 ))
     ];
   }

--- a/lib/core/presentation/widgets/trending_value.dart
+++ b/lib/core/presentation/widgets/trending_value.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:monekin/core/presentation/theme.dart';
 import 'package:monekin/core/presentation/widgets/number_ui_formatters/ui_number_formatter.dart';
+import 'package:monekin/core/utils/color_utils.dart';
 
 class TrendingValue extends StatelessWidget {
   const TrendingValue(
@@ -25,11 +26,22 @@ class TrendingValue extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Icon(
-          percentage >= 0 ? Icons.trending_up : Icons.trending_down,
-          size: fontSize * (9 / 7),
-          color: _getColorBasedOnPercentage(context),
-        ),
+        if (percentage != 0)
+          Icon(
+            percentage > 0 ? Icons.trending_up : Icons.trending_down,
+            size: fontSize * (9 / 7),
+            color: _getColorBasedOnPercentage(context),
+          ),
+        if (percentage == 0)
+          Text(
+            '=',
+            style: TextStyle(
+              height: 1,
+              fontWeight: FontWeight.w700,
+              fontSize: fontSize * (9 / 7),
+              color: _getColorBasedOnPercentage(context),
+            ),
+          ),
         const SizedBox(width: 6),
         UINumberFormatter.percentage(
           amountToConvert: percentage,
@@ -43,9 +55,11 @@ class TrendingValue extends StatelessWidget {
   }
 
   Color _getColorBasedOnPercentage(BuildContext context) {
-    return percentage >= 0
-        ? CustomColors.of(context).success
-        : CustomColors.of(context).danger;
+    return percentage == 0
+        ? CustomColors.of(context).brand.lighten(0.25)
+        : percentage > 0
+            ? CustomColors.of(context).success
+            : CustomColors.of(context).danger;
   }
 
   @override
@@ -56,9 +70,7 @@ class TrendingValue extends StatelessWidget {
         decoration: BoxDecoration(
           color: !filled
               ? null
-              : (percentage >= 0
-                  ? const Color.fromARGB(255, 220, 255, 220)
-                  : const Color.fromARGB(255, 255, 220, 220)),
+              : (_getColorBasedOnPercentage(context).lighten(0.85)),
           borderRadius: BorderRadius.circular(fontSize / 3.5),
           border: outlined
               ? Border.all(color: _getColorBasedOnPercentage(context), width: 1)

--- a/lib/core/presentation/widgets/trending_value.dart
+++ b/lib/core/presentation/widgets/trending_value.dart
@@ -56,7 +56,7 @@ class TrendingValue extends StatelessWidget {
 
   Color _getColorBasedOnPercentage(BuildContext context) {
     return percentage == 0
-        ? CustomColors.of(context).brand.lighten(0.25)
+        ? CustomColors.of(context).brand.lighten(0.35).withBlue(225)
         : percentage > 0
             ? CustomColors.of(context).success
             : CustomColors.of(context).danger;


### PR DESCRIPTION
Before when the trend is equal as the previous period, the trending value displays green, which is not fully correct. Now we display an equal icon with blue colors