### PR TITLE
User can introduce multiples exchanges rates on the same day

### DIFF
--- a/lib/core/database/services/exchange-rate/exchange_rate_service.dart
+++ b/lib/core/database/services/exchange-rate/exchange_rate_service.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:flutter/material.dart';
 import 'package:monekin/core/models/exchange-rate/exchange_rate.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -11,7 +12,16 @@ class ExchangeRateService {
   static final ExchangeRateService instance =
       ExchangeRateService._(AppDB.instance);
 
-  Future<int> insertOrUpdateExchangeRate(ExchangeRateInDB toInsert) {
+  Future<int> insertOrUpdateExchangeRate(ExchangeRateInDB toInsert) async {
+    final elToCompare =
+        (await (getLastExchangeRateOf(currencyCode: toInsert.currencyCode))
+            .first);
+
+    if (elToCompare != null &&
+        DateUtils.isSameDay(elToCompare.date, toInsert.date)) {
+      toInsert = toInsert.copyWith(id: elToCompare.id);
+    }
+
     return db
         .into(db.exchangeRates)
         .insert(toInsert, mode: InsertMode.insertOrReplace);


### PR DESCRIPTION
Fix a bug where the user can introduce multiple exchange rates on the same day.

This was resolved at the front-end level, leaving the possibility in the future to add multiples rates in the same day without changing the database. However, from the very beginning it has always been intended not to give rise to this possibility. For me it is out of the objectives of this app, which after all are personal finances. If someone wants to check exchange rates minute by minute I think they should make use of other types of applications. In addition, the shortest time frame allowed in all charts is daily.

In spite of all this, as I have pointed out before, having several records within the same day is allowed at the database level.