### PR TITLE
Fix bug numberOfAccounts always returns 0

### DIFF
--- a/lib/app/accounts/account_details.dart
+++ b/lib/app/accounts/account_details.dart
@@ -71,8 +71,7 @@ class _AccountDetailsPageState extends State<AccountDetailsPage> {
 
                   final numberOfAccounts = (await AccountService.instance
                           .getAccounts(
-                            predicate: (acc, curr) =>
-                                acc.closingDate.isNotNull(),
+                            predicate: (acc, curr) => acc.closingDate.isNull(),
                           )
                           .first)
                       .length;


### PR DESCRIPTION
I have fixed a bug in the numberOfAccounts variable that always returns 0. This caused the transfer form to be unable to open. The bug was caused by an error in the method used to retrieve data from the database.

hope this helps!