### PR TITLE
Improve cards UI on details pages and fix overflow issues and missing splash effects on this cards

### DIFF
--- a/lib/app/accounts/details/account_details.dart
+++ b/lib/app/accounts/details/account_details.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:monekin/app/accounts/details/account_details_actions.dart';
+import 'package:monekin/app/transactions/label_value_info_list.dart';
 import 'package:monekin/app/transactions/transactions.page.dart';
 import 'package:monekin/app/transactions/widgets/transaction_list.dart';
 import 'package:monekin/core/database/services/account/account_service.dart';
@@ -38,13 +39,16 @@ class AccountDetailsPage extends StatefulWidget {
 }
 
 class _AccountDetailsPageState extends State<AccountDetailsPage> {
-  ListTile buildCopyableTile(String title, String value) {
+  LabelValueInfoListItem buildCopyableTile(String title, String value) {
     final snackbarDisplayer = ScaffoldMessenger.of(context).showSnackBar;
 
-    return ListTile(
-      title: Text(title),
-      subtitle: Text(value),
-      contentPadding: const EdgeInsets.only(left: 16, right: 12),
+    return LabelValueInfoListItem(
+      label: title,
+      value: Text(
+        value,
+        softWrap: false,
+        overflow: TextOverflow.ellipsis,
+      ),
       trailing: IconButton(
           onPressed: () {
             Clipboard.setData(ClipboardData(text: value)).then((_) {
@@ -101,47 +105,46 @@ class _AccountDetailsPageState extends State<AccountDetailsPage> {
                       child: Column(
                         children: [
                           CardWithHeader(
-                              title: 'Info',
-                              body: Column(
-                                children: [
-                                  ListTile(
-                                    title: Text(t.account.date),
-                                    subtitle: Text(
-                                      DateFormat.yMMMMEEEEd()
-                                          .add_Hm()
-                                          .format(account.date),
-                                    ),
+                            title: 'Info',
+                            body: LabelValueInfoList(items: [
+                              LabelValueInfoListItem(
+                                value: Text(
+                                  DateFormat.yMMMMEEEEd()
+                                      .add_Hm()
+                                      .format(account.date),
+                                ),
+                                label: t.account.date,
+                              ),
+                              if (account.isClosed) ...[
+                                LabelValueInfoListItem(
+                                  label: t.account.close_date,
+                                  value: Text(
+                                    DateFormat.yMMMMEEEEd()
+                                        .add_Hm()
+                                        .format(account.closingDate!),
                                   ),
-                                  if (account.isClosed) ...[
-                                    ListTile(
-                                      title: Text(t.account.close_date),
-                                      subtitle: Text(
-                                        DateFormat.yMMMMEEEEd()
-                                            .add_Hm()
-                                            .format(account.closingDate!),
-                                      ),
-                                    ),
-                                  ],
-                                  ListTile(
-                                    title: Text(t.account.types.title),
-                                    subtitle: Text(account.type.title(context)),
-                                  ),
-                                  if (account.description != null) ...[
-                                    ListTile(
-                                      title: Text(t.account.form.notes),
-                                      subtitle: Text(account.description!),
-                                    ),
-                                  ],
-                                  if (account.iban != null) ...[
-                                    buildCopyableTile(
-                                        t.account.form.iban, account.iban!)
-                                  ],
-                                  if (account.swift != null) ...[
-                                    buildCopyableTile(
-                                        t.account.form.swift, account.swift!)
-                                  ]
-                                ],
-                              )),
+                                ),
+                              ],
+                              LabelValueInfoListItem(
+                                label: t.account.types.title,
+                                value: Text(account.type.title(context)),
+                              ),
+                              if (account.iban != null) ...[
+                                buildCopyableTile(
+                                    t.account.form.iban, account.iban!)
+                              ],
+                              if (account.swift != null) ...[
+                                buildCopyableTile(
+                                    t.account.form.swift, account.swift!)
+                              ],
+                              if (account.description != null) ...[
+                                LabelValueInfoListItem(
+                                  label: t.account.form.notes,
+                                  value: Text(account.description!),
+                                ),
+                              ],
+                            ]),
+                          ),
                           const SizedBox(height: 16),
                           CardWithHeader(
                             title: t.home.last_transactions,

--- a/lib/app/transactions/label_value_info_list.dart
+++ b/lib/app/transactions/label_value_info_list.dart
@@ -1,0 +1,38 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:monekin/app/transactions/label_value_info_table.dart';
+import 'package:monekin/core/presentation/app_colors.dart';
+
+class LabelValueInfoListItem extends LabelValueInfoItem {
+  final Widget? trailing;
+
+  LabelValueInfoListItem({
+    required super.value,
+    required super.label,
+    this.trailing,
+  });
+}
+
+class LabelValueInfoList extends StatelessWidget {
+  const LabelValueInfoList({super.key, required this.items});
+
+  final List<LabelValueInfoListItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: items.mapIndexed((index, element) {
+        return ListTile(
+          minVerticalPadding: 0,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          title: Text(element.label),
+          subtitle: element.value,
+          trailing: element.trailing,
+          tileColor: index % 2 == 0
+              ? AppColors.of(context).background
+              : AppColors.of(context).light.withOpacity(0.025),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/app/transactions/label_value_info_table.dart
+++ b/lib/app/transactions/label_value_info_table.dart
@@ -1,0 +1,63 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:monekin/core/presentation/app_colors.dart';
+
+class LabelValueInfoItem {
+  final Widget value;
+  final String label;
+
+  const LabelValueInfoItem({
+    required this.value,
+    required this.label,
+  });
+}
+
+class LabelValueInfoTable extends StatelessWidget {
+  const LabelValueInfoTable({super.key, required this.items});
+
+  final List<LabelValueInfoItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Table(
+      border: TableBorder(borderRadius: BorderRadius.circular(0)),
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      columnWidths: const {
+        0: FlexColumnWidth(3),
+        1: FlexColumnWidth(7),
+      },
+      children: items
+          .mapIndexed(
+            (i, e) => TableRow(
+              decoration: BoxDecoration(
+                color: i % 2 == 0
+                    ? AppColors.of(context).background
+                    : AppColors.of(context).light.withOpacity(0.025),
+              ),
+              children: [
+                TableCell(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      vertical: 12,
+                      horizontal: 16,
+                    ),
+                    child: Text(
+                      e.label,
+                      style: const TextStyle(fontWeight: FontWeight.w300),
+                    ),
+                  ),
+                ),
+                TableCell(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    child: e.value,
+                  ),
+                ),
+              ],
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/app/transactions/transaction_details.page.dart
+++ b/lib/app/transactions/transaction_details.page.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:drift/drift.dart' as drift;
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:monekin/app/transactions/label_value_info_table.dart';
 import 'package:monekin/core/database/services/currency/currency_service.dart';
 import 'package:monekin/core/database/services/exchange-rate/exchange_rate_service.dart';
 import 'package:monekin/core/database/services/transaction/transaction_service.dart';
@@ -251,7 +252,6 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
             width: 1,
             color: transaction.nextPayStatus!
                 .color(context)
-                .darken(0.6)
                 .withOpacity(isNext ? 1 : 0.3),
           )),
       child: ListTile(
@@ -265,18 +265,17 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
           isNext ? transaction.nextPayStatus!.icon : Icons.access_time,
           color: transaction.nextPayStatus!
               .color(context)
-              .darken(0.6)
               .withOpacity(isNext ? 1 : 0.3),
         ),
-        title: Text(
-          DateFormat.yMMMd().format(date),
-          style: TextStyle(color: Colors.black.withOpacity(isNext ? 1 : 0.3)),
-        ),
+        title: Text(DateFormat.yMMMd().format(date)),
         subtitle: !isNext
             ? null
             : Text(
                 transaction.nextPayStatus!
                     .displayDaysToPay(context, transaction.daysToPay()),
+                style: TextStyle(
+                  color: AppColors.of(context).onBackground,
+                ),
               ),
         trailing: Row(mainAxisSize: MainAxisSize.min, children: [
           IconButton(
@@ -367,22 +366,43 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
 
     final color = showRecurrencyStatus
         ? isDarkTheme
-            ? AppColors.of(context).primaryContainer
+            ? AppColors.of(context).primary
             : AppColors.of(context).primary.lighten(0.2)
         : transaction.status!.color;
 
-    return Card(
-      elevation: 1,
-      color: color.lighten(0.625),
+    return Container(
       clipBehavior: Clip.hardEdge,
       margin: const EdgeInsets.only(bottom: 16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        color: color.withOpacity(0.15),
+        border: Border.all(
+          width: 1,
+          color: color,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.of(context).shadowColorLight,
+            blurRadius: 12,
+            offset: const Offset(0, 0),
+            spreadRadius: 4,
+          ),
+        ],
+      ),
       child: Column(
         children: [
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
+                Icon(
+                  showRecurrencyStatus
+                      ? Icons.repeat_rounded
+                      : transaction.status?.icon,
+                  size: 26,
+                  color: color,
+                ),
+                const SizedBox(width: 8),
                 Text(
                     showRecurrencyStatus
                         ? t.recurrent_transactions.details.title
@@ -394,20 +414,10 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w700,
-                      color:
-                          isDarkTheme ? AppColors.of(context).background : null,
                     )),
-                Icon(
-                  showRecurrencyStatus
-                      ? Icons.repeat_rounded
-                      : transaction.status?.icon,
-                  size: 26,
-                  color: color.darken(0.2),
-                )
               ],
             ),
           ),
-          Divider(color: color.lighten(0.25)),
           Padding(
             padding: EdgeInsets.all(showRecurrencyStatus ? 0 : 12),
             child: Column(
@@ -418,10 +428,6 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
                     showRecurrencyStatus
                         ? t.recurrent_transactions.details.descr
                         : transaction.status!.description(context),
-                    style: TextStyle(
-                      color:
-                          isDarkTheme ? AppColors.of(context).background : null,
-                    ),
                   ),
                 ),
                 if (transaction.recurrentInfo.isRecurrent) ...[
@@ -513,60 +519,63 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
                               statusDisplayer(transaction),
                             CardWithHeader(
                               title: 'Info',
-                              bodyPadding:
-                                  const EdgeInsets.symmetric(vertical: 4),
-                              body: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  buildInfoTileWithIconAndColor(
-                                    icon: transaction.account.icon,
-                                    color: transaction.account
-                                        .getComputedColor(context)
-                                        .lighten(isAppInDarkBrightness(context)
-                                            ? 0.5
-                                            : 0),
-                                    data: transaction.account.name,
-                                    title: transaction.isTransfer
-                                        ? t.transfer.form.from
-                                        : t.general.account,
-                                  ),
-                                  if (transaction.isIncomeOrExpense)
-                                    buildInfoTileWithIconAndColor(
-                                      icon: transaction.category!.icon,
-                                      color: ColorHex.get(
-                                              transaction.category!.color)
+                              body: LabelValueInfoTable(
+                                items: [
+                                  LabelValueInfoItem(
+                                    value: buildInfoTileWithIconAndColor(
+                                      icon: transaction.account.icon,
+                                      color: transaction.account
+                                          .getComputedColor(context)
                                           .lighten(
                                               isAppInDarkBrightness(context)
                                                   ? 0.5
                                                   : 0),
-                                      data: transaction.category!.name,
-                                      title: t.general.category,
+                                      data: transaction.account.name,
+                                    ),
+                                    label: transaction.isTransfer
+                                        ? t.transfer.form.from
+                                        : t.general.account,
+                                  ),
+                                  if (transaction.isIncomeOrExpense)
+                                    LabelValueInfoItem(
+                                      value: buildInfoTileWithIconAndColor(
+                                        icon: transaction.category!.icon,
+                                        color: ColorHex.get(
+                                                transaction.category!.color)
+                                            .lighten(
+                                                isAppInDarkBrightness(context)
+                                                    ? 0.5
+                                                    : 0),
+                                        data: transaction.category!.name,
+                                      ),
+                                      label: t.general.category,
                                     ),
                                   if (transaction.isTransfer)
-                                    buildInfoTileWithIconAndColor(
-                                      icon: transaction.receivingAccount!.icon,
-                                      color: AppColors.of(context).primary,
-                                      data: transaction.receivingAccount!.name,
-                                      title: t.transfer.form.to,
-                                    ),
-                                  buildInfoListTile(
-                                    trailing: Text(
+                                    LabelValueInfoItem(
+                                        value: buildInfoTileWithIconAndColor(
+                                          icon: transaction
+                                              .receivingAccount!.icon,
+                                          color: AppColors.of(context).primary,
+                                          data: transaction
+                                              .receivingAccount!.name,
+                                        ),
+                                        label: t.transfer.form.to),
+                                  LabelValueInfoItem(
+                                    value: Text(
                                       DateFormat.yMMMMd()
                                           .format(transaction.date),
                                       softWrap: false,
                                       overflow: TextOverflow.fade,
-                                      textAlign: TextAlign.end,
                                     ),
-                                    title: t.general.time.date,
+                                    label: t.general.time.date,
                                   ),
-                                  buildInfoListTile(
-                                    trailing: Text(
+                                  LabelValueInfoItem(
+                                    value: Text(
                                       DateFormat.Hm().format(transaction.date),
                                       softWrap: false,
                                       overflow: TextOverflow.fade,
-                                      textAlign: TextAlign.end,
                                     ),
-                                    title: t.general.time.time,
+                                    label: t.general.time.time,
                                   ),
                                 ],
                               ),
@@ -760,30 +769,26 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
     );
   }
 
-  ListTile buildInfoTileWithIconAndColor({
+  Row buildInfoTileWithIconAndColor({
     required SupportedIcon icon,
-    required String title,
     required String data,
     required Color color,
   }) {
-    return buildInfoListTile(
-      title: title,
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          icon.display(
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        icon.display(
+          color: color,
+        ),
+        const SizedBox(width: 8),
+        Text(
+          data,
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
             color: color,
           ),
-          const SizedBox(width: 8),
-          Text(
-            data,
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-              color: color,
-            ),
-          )
-        ],
-      ),
+        )
+      ],
     );
   }
 }

--- a/lib/core/presentation/widgets/card_with_header.dart
+++ b/lib/core/presentation/widgets/card_with_header.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 
 import '../app_colors.dart';
 
+/// The radius of the `CardWithHeader` widget, a very useful widget through the app
+const cardWithHeaderRadius = 12.0;
+
 class CardWithHeader extends StatelessWidget {
   const CardWithHeader({
     super.key,
@@ -30,17 +33,18 @@ class CardWithHeader extends StatelessWidget {
       clipBehavior: Clip.hardEdge,
       decoration: BoxDecoration(
         color: AppColors.of(context).background,
+        borderRadius: BorderRadius.circular(cardWithHeaderRadius),
         boxShadow: [
           BoxShadow(
             color: AppColors.of(context).shadowColorLight,
-            blurRadius: 12,
+            blurRadius: cardWithHeaderRadius,
             offset: const Offset(0, 0),
             spreadRadius: 4,
           ),
         ],
       ),
       foregroundDecoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(cardWithHeaderRadius),
         border: Border.all(
           width: 1,
           color: Theme.of(context).dividerColor,

--- a/lib/core/presentation/widgets/card_with_header.dart
+++ b/lib/core/presentation/widgets/card_with_header.dart
@@ -29,12 +29,7 @@ class CardWithHeader extends StatelessWidget {
     return Container(
       clipBehavior: Clip.hardEdge,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
         color: AppColors.of(context).background,
-        border: Border.all(
-          width: 1,
-          color: Theme.of(context).dividerColor,
-        ),
         boxShadow: [
           BoxShadow(
             color: AppColors.of(context).shadowColorLight,
@@ -43,6 +38,13 @@ class CardWithHeader extends StatelessWidget {
             spreadRadius: 4,
           ),
         ],
+      ),
+      foregroundDecoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          width: 1,
+          color: Theme.of(context).dividerColor,
+        ),
       ),
       margin: const EdgeInsets.all(0),
       child: Column(
@@ -79,9 +81,13 @@ class CardWithHeader extends StatelessWidget {
             ),
           ),
           const Divider(),
-          Padding(
-            padding: bodyPadding,
-            child: body,
+          Material(
+            type: MaterialType.transparency,
+            clipBehavior: Clip.antiAliasWithSaveLayer,
+            child: Padding(
+              padding: bodyPadding,
+              child: body,
+            ),
           )
         ],
       ),


### PR DESCRIPTION
This PR fix some issues with the `CardWithHeader` widget, where the splash effects were not visible in some widgets like a `ListTile` or where this splash can overflow the radius of the header.

Also, in the accounts details and in the transaction details pages, the info cards have been redesigned and we also have a completely new status card info in the transaction details screen 