### PR TITLE
Accounts and tags pages do not scroll when overflow

### DIFF
--- a/lib/core/presentation/widgets/monekin_reorderable_list.dart
+++ b/lib/core/presentation/widgets/monekin_reorderable_list.dart
@@ -25,7 +25,7 @@ class _MonekinReorderableListState extends State<MonekinReorderableList> {
   Widget build(BuildContext context) {
     return ReorderableListView.builder(
       shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
+      physics: const BouncingScrollPhysics(),
       itemBuilder: (context, index) => Opacity(
         key: Key(index.toString()),
         opacity: isOrderingItem == null || isOrderingItem == index ? 1 : 0.4,


### PR DESCRIPTION
The all accounts and the all tags page do not scroll when needed. These pages are accessible right now from the "More" option in the main menu.