### PR TITLE
Category picker do not show all categories

### DIFF
--- a/lib/app/categories/selectors/category_picker.dart
+++ b/lib/app/categories/selectors/category_picker.dart
@@ -31,12 +31,12 @@ Future<Category?> showCategoryPickerModal(
 }
 
 class CategoryPicker extends StatefulWidget {
-  CategoryPicker(
-      {super.key,
-      required this.selectedCategory,
-      required this.categoryType,
-      this.showSubcategories = true})
-      : assert(categoryType.isNotEmpty);
+  CategoryPicker({
+    super.key,
+    required this.selectedCategory,
+    required this.categoryType,
+    this.showSubcategories = true,
+  }) : assert(categoryType.isNotEmpty);
 
   final Category? selectedCategory;
   final List<CategoryType> categoryType;

--- a/lib/app/transactions/form/transaction_form.page.dart
+++ b/lib/app/transactions/form/transaction_form.page.dart
@@ -112,8 +112,18 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     _tabController.addListener(() {
       transactionType = TransactionType.values.elementAt(_tabController.index);
 
+      // Function to execute when the transaction mode change:
       if (transactionType.isTransfer && transactionValue.isNegative) {
         transactionValue = transactionValue * -1;
+      }
+
+      if (selectedCategory != null &&
+          (selectedCategory!.type == CategoryType.E &&
+                  transactionType == TransactionType.I ||
+              selectedCategory!.type == CategoryType.I &&
+                  transactionType == TransactionType.E)) {
+        // Unselect the selected category if the transactionType don't match
+        selectedCategory = null;
       }
 
       setState(() {});
@@ -202,9 +212,6 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   }
 
   submitForm() {
-    print("HOLAALLALA");
-    print(transactionType.isTransfer);
-    print(transferAccount);
     if (transactionType.isIncomeOrExpense && selectedCategory == null ||
         transactionType.isTransfer && transferAccount == null) {
       _shakeKey.currentState?.shake();
@@ -325,8 +332,8 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       modal: CategoryPicker(
         selectedCategory: selectedCategory,
         categoryType: transactionType == TransactionType.E
-            ? [CategoryType.E]
-            : [CategoryType.I],
+            ? [CategoryType.E, CategoryType.B]
+            : [CategoryType.I, CategoryType.B],
       ),
     );
 


### PR DESCRIPTION
This fixes #222. 

In this PR also we reset the category when its type don't match with the selected transaction type to add/edit in the transaction form