### PR TITLE
Improve settings performance and fix initially wrong blur state in the amounts 

### DIFF
--- a/lib/app/currencies/currency_manager.dart
+++ b/lib/app/currencies/currency_manager.dart
@@ -45,7 +45,7 @@ class _CurrencyManagerPageState extends State<CurrencyManagerPage> {
       if (isConfirmed != true) return;
 
       UserSettingService.instance
-          .setSetting(SettingKey.preferredCurrency, newCurrency.code)
+          .setItem(SettingKey.preferredCurrency, newCurrency.code)
           .then(
         (value) {
           setState(() {

--- a/lib/app/home/dashboard.page.dart
+++ b/lib/app/home/dashboard.page.dart
@@ -250,8 +250,8 @@ class _DashboardPageState extends State<DashboardPage> {
           children: [
             if (BreakPoint.of(context).isSmallerThan(BreakpointID.md)) ...[
               StreamBuilder(
-                  stream:
-                      UserSettingService.instance.getSetting(SettingKey.avatar),
+                  stream: UserSettingService.instance
+                      .getSettingFromDB(SettingKey.avatar),
                   builder: (context, snapshot) {
                     return UserAvatar(
                       avatar: snapshot.data,
@@ -282,7 +282,7 @@ class _DashboardPageState extends State<DashboardPage> {
                 ),
                 StreamBuilder(
                     stream: UserSettingService.instance
-                        .getSetting(SettingKey.userName),
+                        .getSettingFromDB(SettingKey.userName),
                     builder: (context, snapshot) {
                       if (!snapshot.hasData) {
                         return const Skeleton(width: 70, height: 12);

--- a/lib/app/home/widgets/home_drawer.dart
+++ b/lib/app/home/widgets/home_drawer.dart
@@ -27,7 +27,7 @@ class HomeDrawer extends StatelessWidget {
         onDestinationSelected: onDestinationSelected,
         children: [
           StreamBuilder(
-              stream: UserSettingService.instance.getAllItemsFromDB(
+              stream: UserSettingService.instance.getItemsFromDB(
                 (p0) =>
                     p0.settingKey.equalsValue(SettingKey.userName) |
                     p0.settingKey.equalsValue(SettingKey.avatar),

--- a/lib/app/home/widgets/home_drawer.dart
+++ b/lib/app/home/widgets/home_drawer.dart
@@ -27,7 +27,7 @@ class HomeDrawer extends StatelessWidget {
         onDestinationSelected: onDestinationSelected,
         children: [
           StreamBuilder(
-              stream: UserSettingService.instance.getSettingsFromDB(
+              stream: UserSettingService.instance.getAllItemsFromDB(
                 (p0) =>
                     p0.settingKey.equalsValue(SettingKey.userName) |
                     p0.settingKey.equalsValue(SettingKey.avatar),

--- a/lib/app/home/widgets/home_drawer.dart
+++ b/lib/app/home/widgets/home_drawer.dart
@@ -27,7 +27,7 @@ class HomeDrawer extends StatelessWidget {
         onDestinationSelected: onDestinationSelected,
         children: [
           StreamBuilder(
-              stream: UserSettingService.instance.getSettings(
+              stream: UserSettingService.instance.getSettingsFromDB(
                 (p0) =>
                     p0.settingKey.equalsValue(SettingKey.userName) |
                     p0.settingKey.equalsValue(SettingKey.avatar),

--- a/lib/app/layout/navigation_sidebar.dart
+++ b/lib/app/layout/navigation_sidebar.dart
@@ -79,7 +79,7 @@ class NavigationSidebarState extends State<NavigationSidebar> {
                     padding: const EdgeInsets.only(bottom: 16, top: 16),
                     child: StreamBuilder(
                         stream: UserSettingService.instance
-                            .getSetting(SettingKey.avatar),
+                            .getSettingFromDB(SettingKey.avatar),
                         builder: (context, snapshot) {
                           return UserAvatar(avatar: snapshot.data);
                         }),

--- a/lib/app/onboarding/onboarding.dart
+++ b/lib/app/onboarding/onboarding.dart
@@ -23,15 +23,15 @@ class _OnboardingPageState extends State<OnboardingPage> {
   int currentPage = 0;
 
   introFinished() {
-    AppDataService.instance.setItem(AppDataKey.introSeen, '1').then(
+    AppDataService.instance
+        .setItem(AppDataKey.introSeen, '1', updateGlobalState: true)
+        .then(
       (value) {
         RouteUtils.pushRoute(
           context,
           TabsPage(key: tabsPageKey),
           withReplacement: true,
         );
-
-        refresh++;
       },
     );
   }

--- a/lib/app/onboarding/onboarding.dart
+++ b/lib/app/onboarding/onboarding.dart
@@ -23,7 +23,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
   int currentPage = 0;
 
   introFinished() {
-    AppDataService.instance.setAppDataItem(AppDataKey.introSeen, '1').then(
+    AppDataService.instance.setItem(AppDataKey.introSeen, '1').then(
       (value) {
         RouteUtils.pushRoute(
           context,
@@ -136,8 +136,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
                                     preselectedCurrency: userCurrency,
                                     onCurrencySelected: (newCurrency) {
                                       UserSettingService.instance
-                                          .setSetting(
-                                              SettingKey.preferredCurrency,
+                                          .setItem(SettingKey.preferredCurrency,
                                               newCurrency.code)
                                           .then((value) => setState(() => {}));
                                     }));

--- a/lib/app/settings/appearance_settings_page.dart
+++ b/lib/app/settings/appearance_settings_page.dart
@@ -140,8 +140,11 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
                     listenToDeviceLocale: true);
 
                 try {
-                  await UserSettingService.instance
-                      .setSetting(SettingKey.appLanguage, newLang);
+                  await UserSettingService.instance.setSetting(
+                    SettingKey.appLanguage,
+                    newLang,
+                    updateGlobalState: true,
+                  );
                 } catch (e) {
                   snackbarDisplayer(const SnackBar(
                     content: Text(
@@ -153,7 +156,7 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
             createListSeparator(context, t.settings.theme_and_colors),
             StreamBuilder(
                 stream: UserSettingService.instance
-                    .getSetting(SettingKey.themeMode),
+                    .getSettingFromDB(SettingKey.themeMode),
                 builder: (context, snapshot) {
                   return buildSelector(
                     title: t.settings.theme,
@@ -165,7 +168,11 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
                     selected: snapshot.data ?? 'system',
                     onChanged: (value) {
                       UserSettingService.instance
-                          .setSetting(SettingKey.themeMode, value)
+                          .setSetting(
+                            SettingKey.themeMode,
+                            value,
+                            updateGlobalState: true,
+                          )
                           .then((value) => null);
                     },
                   );
@@ -175,24 +182,31 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
               subtitle: t.settings.amoled_mode_descr,
               initialValue: appStateSettings[SettingKey.amoledMode] == '1',
               disabled: Theme.of(context).brightness == Brightness.light,
-              onSwitched: (bool value) async {
-                await UserSettingService.instance
-                    .setSetting(SettingKey.amoledMode, value ? '1' : '0');
+              onSwitchDebounceMs: 200,
+              onSwitch: (bool value) async {
+                await UserSettingService.instance.setSetting(
+                  SettingKey.amoledMode,
+                  value ? '1' : '0',
+                  updateGlobalState: true,
+                );
               },
             ),
             MonekinTileSwitch(
               title: t.settings.dynamic_colors,
               subtitle: t.settings.dynamic_colors_descr,
               initialValue: appStateSettings[SettingKey.accentColor] == 'auto',
-              onSwitched: (bool value) async {
+              onSwitchDebounceMs: 200,
+              onSwitch: (bool value) async {
                 await UserSettingService.instance.setSetting(
-                    SettingKey.accentColor,
-                    value ? 'auto' : brandBlue.toHex(leadingHashSign: false));
+                  SettingKey.accentColor,
+                  value ? 'auto' : brandBlue.toHex(leadingHashSign: false),
+                  updateGlobalState: true,
+                );
               },
             ),
             StreamBuilder(
                 stream: UserSettingService.instance
-                    .getSetting(SettingKey.accentColor),
+                    .getSettingFromDB(SettingKey.accentColor),
                 initialData: 'auto',
                 builder: (context, snapshot) {
                   late final Color color;
@@ -220,7 +234,10 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
 
                               setState(() {
                                 UserSettingService.instance.setSetting(
-                                    SettingKey.accentColor, value.toHex());
+                                  SettingKey.accentColor,
+                                  value.toHex(),
+                                  updateGlobalState: true,
+                                );
                               });
                             }),
                     title: Text(t.settings.accent_color),
@@ -250,19 +267,19 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
               icon: Icons.phonelink_lock_outlined,
               initialValue:
                   appStateSettings[SettingKey.privateModeAtLaunch] == '1',
-              onSwitched: (bool value) async {
+              onSwitch: (bool value) async {
                 await PrivateModeService.instance.setPrivateModeAtLaunch(value);
               },
             ),
             StreamBuilder(
                 stream: PrivateModeService.instance.privateModeStream,
                 builder: (context, snapshot) {
-                  return SwitchListTile(
-                    title: Text(t.settings.security.private_mode),
-                    subtitle: Text(t.settings.security.private_mode_descr),
-                    secondary: const Icon(Icons.lock),
-                    value: snapshot.data ?? false,
-                    onChanged: (bool value) {
+                  return MonekinTileSwitch(
+                    title: t.settings.security.private_mode,
+                    subtitle: t.settings.security.private_mode_descr,
+                    icon: Icons.lock,
+                    initialValue: snapshot.data ?? false,
+                    onSwitch: (bool value) {
                       setState(() {
                         PrivateModeService.instance.setPrivateMode(value);
                       });

--- a/lib/app/settings/appearance_settings_page.dart
+++ b/lib/app/settings/appearance_settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:monekin/app/settings/widgets/language_selector.dart';
+import 'package:monekin/app/settings/widgets/monekin_tile_switch.dart';
 import 'package:monekin/app/settings/widgets/supported_locales.dart';
 import 'package:monekin/core/database/services/user-setting/private_mode_service.dart';
 import 'package:monekin/core/database/services/user-setting/user_setting_service.dart';
@@ -169,47 +170,26 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
                     },
                   );
                 }),
-            StreamBuilder(
-                stream: UserSettingService.instance
-                    .getSetting(SettingKey.amoledMode)
-                    .map((event) => event == '1'),
-                initialData: true,
-                builder: (context, snapshot) {
-                  return SwitchListTile(
-                    title: Text(t.settings.amoled_mode),
-                    subtitle: Text(t.settings.amoled_mode_descr),
-                    value: snapshot.data!,
-                    onChanged: Theme.of(context).brightness == Brightness.light
-                        ? null
-                        : (bool value) {
-                            setState(() {
-                              UserSettingService.instance.setSetting(
-                                  SettingKey.amoledMode, value ? '1' : '0');
-                            });
-                          },
-                  );
-                }),
-            StreamBuilder(
-                stream: UserSettingService.instance
-                    .getSetting(SettingKey.accentColor)
-                    .map((event) => event == 'auto'),
-                initialData: true,
-                builder: (context, snapshot) {
-                  return SwitchListTile(
-                    title: Text(t.settings.dynamic_colors),
-                    subtitle: Text(t.settings.dynamic_colors_descr),
-                    value: snapshot.data!,
-                    onChanged: (bool value) {
-                      setState(() {
-                        UserSettingService.instance.setSetting(
-                            SettingKey.accentColor,
-                            value
-                                ? 'auto'
-                                : brandBlue.toHex(leadingHashSign: false));
-                      });
-                    },
-                  );
-                }),
+            MonekinTileSwitch(
+              title: t.settings.amoled_mode,
+              subtitle: t.settings.amoled_mode_descr,
+              initialValue: appStateSettings[SettingKey.amoledMode] == '1',
+              disabled: Theme.of(context).brightness == Brightness.light,
+              onSwitched: (bool value) async {
+                await UserSettingService.instance
+                    .setSetting(SettingKey.amoledMode, value ? '1' : '0');
+              },
+            ),
+            MonekinTileSwitch(
+              title: t.settings.dynamic_colors,
+              subtitle: t.settings.dynamic_colors_descr,
+              initialValue: appStateSettings[SettingKey.accentColor] == 'auto',
+              onSwitched: (bool value) async {
+                await UserSettingService.instance.setSetting(
+                    SettingKey.accentColor,
+                    value ? 'auto' : brandBlue.toHex(leadingHashSign: false));
+              },
+            ),
             StreamBuilder(
                 stream: UserSettingService.instance
                     .getSetting(SettingKey.accentColor),
@@ -264,23 +244,14 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
                   );
                 }),
             createListSeparator(context, t.settings.security.title),
-            StreamBuilder(
-              stream: PrivateModeService.instance.getPrivateModeAtLaunch(),
-              builder: (context, snapshot) {
-                return SwitchListTile(
-                  title: Text(t.settings.security.private_mode_at_launch),
-                  subtitle:
-                      Text(t.settings.security.private_mode_at_launch_descr),
-                  secondary: const Icon(Icons.phonelink_lock_outlined),
-                  value: snapshot.data ?? false,
-                  onChanged: (bool value) {
-                    PrivateModeService.instance
-                        .setPrivateModeAtLaunch(value)
-                        .then((i) {
-                      setState(() {});
-                    });
-                  },
-                );
+            MonekinTileSwitch(
+              title: t.settings.security.private_mode_at_launch,
+              subtitle: t.settings.security.private_mode_at_launch_descr,
+              icon: Icons.phonelink_lock_outlined,
+              initialValue:
+                  appStateSettings[SettingKey.privateModeAtLaunch] == '1',
+              onSwitched: (bool value) async {
+                await PrivateModeService.instance.setPrivateModeAtLaunch(value);
               },
             ),
             StreamBuilder(

--- a/lib/app/settings/appearance_settings_page.dart
+++ b/lib/app/settings/appearance_settings_page.dart
@@ -140,7 +140,7 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
                     listenToDeviceLocale: true);
 
                 try {
-                  await UserSettingService.instance.setSetting(
+                  await UserSettingService.instance.setItem(
                     SettingKey.appLanguage,
                     newLang,
                     updateGlobalState: true,
@@ -168,7 +168,7 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
                     selected: snapshot.data ?? 'system',
                     onChanged: (value) {
                       UserSettingService.instance
-                          .setSetting(
+                          .setItem(
                             SettingKey.themeMode,
                             value,
                             updateGlobalState: true,
@@ -184,7 +184,7 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
               disabled: Theme.of(context).brightness == Brightness.light,
               onSwitchDebounceMs: 200,
               onSwitch: (bool value) async {
-                await UserSettingService.instance.setSetting(
+                await UserSettingService.instance.setItem(
                   SettingKey.amoledMode,
                   value ? '1' : '0',
                   updateGlobalState: true,
@@ -197,7 +197,7 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
               initialValue: appStateSettings[SettingKey.accentColor] == 'auto',
               onSwitchDebounceMs: 200,
               onSwitch: (bool value) async {
-                await UserSettingService.instance.setSetting(
+                await UserSettingService.instance.setItem(
                   SettingKey.accentColor,
                   value ? 'auto' : brandBlue.toHex(leadingHashSign: false),
                   updateGlobalState: true,
@@ -233,7 +233,7 @@ class _AdvancedSettingsPageState extends State<AdvancedSettingsPage> {
                               if (value == null) return;
 
                               setState(() {
-                                UserSettingService.instance.setSetting(
+                                UserSettingService.instance.setItem(
                                   SettingKey.accentColor,
                                   value.toHex(),
                                   updateGlobalState: true,

--- a/lib/app/settings/edit_profile_modal.dart
+++ b/lib/app/settings/edit_profile_modal.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:monekin/core/database/services/user-setting/user_setting_service.dart';
 import 'package:monekin/core/presentation/widgets/bottomSheetFooter.dart';
 import 'package:monekin/core/presentation/widgets/modal_container.dart';
+import 'package:monekin/core/presentation/widgets/tappable.dart';
 import 'package:monekin/core/presentation/widgets/user_avatar.dart';
 import 'package:monekin/core/utils/text_field_utils.dart';
 import 'package:monekin/i18n/translations.g.dart';
@@ -38,22 +39,13 @@ class _EditProfileModalState extends State<EditProfileModal> {
   void initState() {
     super.initState();
 
-    final userSettingsService = UserSettingService.instance;
-
-    userSettingsService.getSetting(SettingKey.avatar).first.then((value) {
-      setState(() {
-        selectedAvatar = value;
-      });
-    });
-
-    userSettingsService.getSetting(SettingKey.userName).first.then((value) {
-      _nameController.value = TextEditingValue(text: value ?? '');
-    });
+    selectedAvatar = appStateSettings[SettingKey.avatar];
+    _nameController.value =
+        TextEditingValue(text: appStateSettings[SettingKey.userName] ?? '');
   }
 
   @override
   Widget build(BuildContext context) {
-    final ColorScheme colors = Theme.of(context).colorScheme;
     final t = Translations.of(context);
 
     return ModalContainer(
@@ -100,24 +92,31 @@ class _EditProfileModalState extends State<EditProfileModal> {
               runSpacing: 12, // gap between lines
               alignment: WrapAlignment.center,
               children: allAvatars
-                  .map((e) => InkWell(
-                        onTap: () {
-                          HapticFeedback.lightImpact();
-                          setState(() {
-                            selectedAvatar = e;
-                          });
-                        },
-                        child: UserAvatar(
-                          avatar: e,
-                          size: 52,
-                          border: selectedAvatar == e
-                              ? Border.all(width: 2, color: colors.primary)
-                              : Border.all(width: 2, color: Colors.transparent),
-                        ),
-                      ))
+                  .map((avatarName) => buildTappableAvatar(context, avatarName))
                   .toList(),
             ),
           ],
         ));
+  }
+
+  Tappable buildTappableAvatar(BuildContext context, String avatarName) {
+    return Tappable(
+      borderRadius: BorderRadius.circular(888),
+      bgColor: Theme.of(context).colorScheme.primaryContainer,
+      onTap: () {
+        HapticFeedback.lightImpact();
+        setState(() {
+          selectedAvatar = avatarName;
+        });
+      },
+      child: UserAvatar(
+        avatar: avatarName,
+        size: 52,
+        backgroundColor: Colors.transparent,
+        border: selectedAvatar == avatarName
+            ? Border.all(width: 2, color: Theme.of(context).colorScheme.primary)
+            : Border.all(width: 2, color: Colors.transparent),
+      ),
+    );
   }
 }

--- a/lib/app/settings/edit_profile_modal.dart
+++ b/lib/app/settings/edit_profile_modal.dart
@@ -60,9 +60,9 @@ class _EditProfileModalState extends State<EditProfileModal> {
                       final userSettingsService = UserSettingService.instance;
 
                       Future.wait([
-                        userSettingsService.setSetting(
+                        userSettingsService.setItem(
                             SettingKey.userName, _nameController.text),
-                        userSettingsService.setSetting(
+                        userSettingsService.setItem(
                             SettingKey.avatar, selectedAvatar!)
                       ].map((e) => Future.value(e))).then((value) {
                         Navigator.pop(context);

--- a/lib/app/settings/widgets/monekin_tile_switch.dart
+++ b/lib/app/settings/widgets/monekin_tile_switch.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+class MonekinTileSwitch extends StatefulWidget {
+  const MonekinTileSwitch({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.initialValue = false,
+    this.icon,
+    required this.onSwitched,
+    this.syncWithInitialValue = true,
+    this.disabled = false,
+  });
+
+  final String title;
+  final String? subtitle;
+  final bool initialValue;
+  final IconData? icon;
+  final Function(bool)? onSwitched;
+  final bool syncWithInitialValue;
+  final bool disabled;
+
+  @override
+  State<MonekinTileSwitch> createState() => _MonekinTileSwitchState();
+}
+
+class _MonekinTileSwitchState extends State<MonekinTileSwitch> {
+  bool value = true;
+
+  @override
+  void initState() {
+    super.initState();
+    value = widget.initialValue;
+  }
+
+  @override
+  void didUpdateWidget(MonekinTileSwitch oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.initialValue != value && widget.syncWithInitialValue) {
+      setState(() {
+        value = widget.initialValue;
+      });
+    }
+  }
+
+  Future<void> toggleSwitch() async {
+    if (widget.onSwitched == null) {
+      return;
+    }
+
+    setState(() {
+      value = !value;
+    });
+
+    try {
+      await widget.onSwitched!(value);
+    } catch (e) {
+      setState(() {
+        value = !value;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      title: Text(widget.title),
+      subtitle: widget.subtitle == null ? null : Text(widget.subtitle!),
+      secondary: widget.icon == null ? null : Icon(widget.icon),
+      value: value,
+      onChanged: widget.disabled
+          ? null
+          : (_) {
+              toggleSwitch();
+            },
+    );
+  }
+}

--- a/lib/app/settings/widgets/monekin_tile_switch.dart
+++ b/lib/app/settings/widgets/monekin_tile_switch.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:monekin/core/utils/debouncer.dart';
 
 class MonekinTileSwitch extends StatefulWidget {
   const MonekinTileSwitch({
@@ -7,17 +10,36 @@ class MonekinTileSwitch extends StatefulWidget {
     this.subtitle,
     this.initialValue = false,
     this.icon,
-    required this.onSwitched,
+    required this.onSwitch,
     this.syncWithInitialValue = true,
     this.disabled = false,
+    this.onSwitchDebounceMs = 0,
+    this.restoreValueOnSwitchError = true,
+    this.onSwitchError,
   });
 
   final String title;
   final String? subtitle;
   final bool initialValue;
   final IconData? icon;
-  final Function(bool)? onSwitched;
+
+  /// Callback triggered when the switch value changes.
+  ///
+  /// The callback provides the new value as a parameter.
+  final Function(bool)? onSwitch;
+
+  /// Callback triggered when an error occurs during [onSwitch].
+  final Function()? onSwitchError;
+
+  /// Whether the switch toggle value should be restored to its previous state if [onSwitch] throws an error.
+  final bool restoreValueOnSwitchError;
+
+  /// The debounce duration in milliseconds before [onSwitch] is triggered.
+  final int onSwitchDebounceMs;
+
   final bool syncWithInitialValue;
+
+  /// Whether the switch is disabled and cannot be interacted with
   final bool disabled;
 
   @override
@@ -26,11 +48,13 @@ class MonekinTileSwitch extends StatefulWidget {
 
 class _MonekinTileSwitchState extends State<MonekinTileSwitch> {
   bool value = true;
+  late final Debouncer _debouncer;
 
   @override
   void initState() {
     super.initState();
     value = widget.initialValue;
+    _debouncer = Debouncer(milliseconds: widget.onSwitchDebounceMs);
   }
 
   @override
@@ -45,21 +69,28 @@ class _MonekinTileSwitchState extends State<MonekinTileSwitch> {
   }
 
   Future<void> toggleSwitch() async {
-    if (widget.onSwitched == null) {
+    if (widget.onSwitch == null) {
       return;
     }
 
-    setState(() {
-      value = !value;
-    });
+    value = !value;
 
-    try {
-      await widget.onSwitched!(value);
-    } catch (e) {
-      setState(() {
-        value = !value;
-      });
-    }
+    setState(() {});
+
+    _debouncer.run(() async {
+      try {
+        await widget.onSwitch!(value);
+      } catch (e) {
+        if (widget.onSwitchError != null) {
+          widget.onSwitchError!();
+        }
+
+        if (widget.restoreValueOnSwitchError) {
+          value = !value;
+          setState(() {});
+        }
+      }
+    });
   }
 
   @override

--- a/lib/core/database/app_db.dart
+++ b/lib/core/database/app_db.dart
@@ -60,7 +60,7 @@ class AppDB extends _$AppDB {
       }
 
       await AppDataService.instance
-          .setAppDataItem(AppDataKey.dbVersion, i.toStringAsFixed(0));
+          .setItem(AppDataKey.dbVersion, i.toStringAsFixed(0));
     }
 
     Logger.printDebug('Migration completed!');

--- a/lib/core/database/services/app-data/app_data_service.dart
+++ b/lib/core/database/services/app-data/app_data_service.dart
@@ -1,30 +1,29 @@
-import 'package:drift/drift.dart';
 import 'package:monekin/core/database/app_db.dart';
+import 'package:monekin/core/database/services/shared/key_value_pair.dart';
+import 'package:monekin/core/database/services/shared/key_value_service.dart';
 
 /// The keys of the avalaible settings of the app
 enum AppDataKey { dbVersion, introSeen, lastExportDate }
 
-class AppDataService {
-  final AppDB db;
+final Map<AppDataKey, String?> appStateData = {};
 
-  AppDataService._(this.db);
-  static final AppDataService instance = AppDataService._(AppDB.instance);
+class AppDataService extends KeyValueService<AppDataKey, AppData, AppDataData> {
+  AppDataService._(AppDB db)
+      : super(
+          db: db,
+          table: db.appData,
+          globalStateMap: appStateData,
+          rowToKeyPairInstance: (row) => KeyValuePairInDB.fromAppData(row),
+          toDbRow: (x) => x.toAppDataItem(),
+        );
 
-  Future<int> setAppDataItem(AppDataKey appDataKey, String? appDataValue) {
-    return db.into(db.appData).insert(
-        AppDataData(appDataKey: appDataKey, appDataValue: appDataValue),
-        mode: InsertMode.insertOrReplace);
-  }
+  static final AppDataService _instance = AppDataService._(AppDB.instance);
+  static AppDataService get instance => _instance;
 
   Stream<String?> getAppDataItem(AppDataKey appDataKey) {
     return (db.select(db.appData)
           ..where((tbl) => tbl.appDataKey.equalsValue(appDataKey)))
         .map((e) => e.appDataValue)
         .watchSingleOrNull();
-  }
-
-  Stream<List<AppDataData>> getAppDataItems(
-      Expression<bool> Function(AppData) filter) {
-    return (db.select(db.appData)..where(filter)).watch();
   }
 }

--- a/lib/core/database/services/currency/currency_service.dart
+++ b/lib/core/database/services/currency/currency_service.dart
@@ -57,7 +57,7 @@ class CurrencyService {
       if (currencyCode == null) {
         currencyCode = await getDeviceDefaultCurrencyCode();
 
-        await settingService.setSetting(
+        await settingService.setItem(
             SettingKey.preferredCurrency, currencyCode);
       }
 

--- a/lib/core/database/services/currency/currency_service.dart
+++ b/lib/core/database/services/currency/currency_service.dart
@@ -52,7 +52,7 @@ class CurrencyService {
     final settingService = UserSettingService.instance;
 
     return settingService
-        .getSetting(SettingKey.preferredCurrency)
+        .getSettingFromDB(SettingKey.preferredCurrency)
         .asyncMap((currencyCode) async {
       if (currencyCode == null) {
         currencyCode = await getDeviceDefaultCurrencyCode();

--- a/lib/core/database/services/shared/key_value_pair.dart
+++ b/lib/core/database/services/shared/key_value_pair.dart
@@ -1,0 +1,29 @@
+import 'package:monekin/core/database/app_db.dart';
+import 'package:monekin/core/database/services/app-data/app_data_service.dart';
+import 'package:monekin/core/database/services/user-setting/user_setting_service.dart';
+
+class KeyValuePairInDB<T extends Enum> {
+  final T key;
+  final String? value;
+
+  KeyValuePairInDB({
+    required this.key,
+    required this.value,
+  });
+
+  static KeyValuePairInDB<SettingKey> fromUserSetting(UserSetting x) {
+    return KeyValuePairInDB(key: x.settingKey, value: x.settingValue);
+  }
+
+  static KeyValuePairInDB<AppDataKey> fromAppData(AppDataData x) {
+    return KeyValuePairInDB(key: x.appDataKey, value: x.appDataValue);
+  }
+
+  UserSetting toUserSetting() {
+    return UserSetting(settingKey: key as SettingKey, settingValue: value);
+  }
+
+  AppDataData toAppDataItem() {
+    return AppDataData(appDataKey: key as AppDataKey, appDataValue: value);
+  }
+}

--- a/lib/core/database/services/shared/key_value_service.dart
+++ b/lib/core/database/services/shared/key_value_service.dart
@@ -58,7 +58,7 @@ abstract class KeyValueService<KeyType extends Enum, TableType extends Table,
     return true;
   }
 
-  Stream<List<RowType>> getAllItemsFromDB(
+  Stream<List<RowType>> getItemsFromDB(
       Expression<bool> Function(TableType) filter) {
     return (db.select(table)..where(filter)).watch();
   }

--- a/lib/core/database/services/shared/key_value_service.dart
+++ b/lib/core/database/services/shared/key_value_service.dart
@@ -1,0 +1,65 @@
+import 'package:drift/drift.dart';
+import 'package:monekin/core/database/app_db.dart';
+import 'package:monekin/core/database/services/shared/key_value_pair.dart';
+import 'package:monekin/main.dart';
+
+/// Base service to handle key-value pairs for any table
+abstract class KeyValueService<KeyType extends Enum, TableType extends Table,
+    RowType> {
+  final AppDB db;
+  final TableInfo<TableType, RowType> table;
+  final Map<KeyType, String?> globalStateMap;
+  final KeyValuePairInDB<KeyType> Function(RowType) rowToKeyPairInstance;
+  final Insertable<RowType> Function(KeyValuePairInDB<KeyType>) toDbRow;
+
+  KeyValueService({
+    required this.db,
+    required this.table,
+    required this.globalStateMap,
+    required this.rowToKeyPairInstance,
+    required this.toDbRow,
+  });
+
+  Future<void> initializeGlobalStateMap() async {
+    final savedSettings = await db.select(table).watch().first;
+
+    for (final savedSetting in savedSettings.map(rowToKeyPairInstance)) {
+      globalStateMap[savedSetting.key] = savedSetting.value;
+    }
+  }
+
+  Future<bool> setItem(
+    KeyType itemKey,
+    String? itemValue, {
+    bool updateGlobalState = false,
+  }) async {
+    final previousValue = globalStateMap[itemKey];
+
+    if (previousValue == itemValue) {
+      return false;
+    }
+
+    globalStateMap[itemKey] = itemValue;
+
+    try {
+      await db.into(table).insert(
+            toDbRow(KeyValuePairInDB(key: itemKey, value: itemValue)),
+            mode: InsertMode.insertOrReplace,
+          );
+
+      if (updateGlobalState == true) {
+        appStateKey.currentState?.refreshAppState();
+      }
+    } catch (e) {
+      globalStateMap[itemKey] = previousValue; // Restore previous value
+      rethrow; // Allow caller to handle the error
+    }
+
+    return true;
+  }
+
+  Stream<List<RowType>> getAllItemsFromDB(
+      Expression<bool> Function(TableType) filter) {
+    return (db.select(table)..where(filter)).watch();
+  }
+}

--- a/lib/core/database/services/user-setting/private_mode_service.dart
+++ b/lib/core/database/services/user-setting/private_mode_service.dart
@@ -23,7 +23,7 @@ class PrivateModeService {
 
   /// Set if the app should start in private mode
   Future<bool> setPrivateModeAtLaunch(bool value) async {
-    final result = await userSettingsService.setSetting(
+    final result = await userSettingsService.setItem(
         SettingKey.privateModeAtLaunch, value ? '1' : '0');
 
     return result;

--- a/lib/core/database/services/user-setting/private_mode_service.dart
+++ b/lib/core/database/services/user-setting/private_mode_service.dart
@@ -17,26 +17,15 @@ class PrivateModeService {
     _privateModeController.close();
   }
 
-  Future<void> initializePrivateMode() async {
-    setPrivateMode(await getPrivateModeAtLaunch().first);
-  }
-
   void setPrivateMode(bool value) {
     _privateModeController.add(value);
   }
 
   /// Set if the app should start in private mode
-  Future<int> setPrivateModeAtLaunch(bool value) async {
+  Future<bool> setPrivateModeAtLaunch(bool value) async {
     final result = await userSettingsService.setSetting(
         SettingKey.privateModeAtLaunch, value ? '1' : '0');
 
     return result;
-  }
-
-  /// Get if the app should start in private mode:
-  Stream<bool> getPrivateModeAtLaunch() {
-    return userSettingsService
-        .getSetting(SettingKey.privateModeAtLaunch)
-        .map((x) => x == '1');
   }
 }

--- a/lib/core/database/services/user-setting/utils/get_theme_from_string.dart
+++ b/lib/core/database/services/user-setting/utils/get_theme_from_string.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+ThemeMode getThemeFromString(String themeString) {
+  Map<String, ThemeMode> themeSetting = {
+    'system': ThemeMode.system,
+    'light': ThemeMode.light,
+    'dark': ThemeMode.dark,
+  };
+
+  return themeSetting[themeString] ?? ThemeMode.system;
+}

--- a/lib/core/presentation/widgets/number_ui_formatters/currency_displayer.dart
+++ b/lib/core/presentation/widgets/number_ui_formatters/currency_displayer.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:monekin/core/database/app_db.dart';
 import 'package:monekin/core/database/services/currency/currency_service.dart';
 import 'package:monekin/core/database/services/user-setting/private_mode_service.dart';
+import 'package:monekin/core/database/services/user-setting/user_setting_service.dart';
 import 'package:monekin/core/presentation/widgets/skeleton.dart';
 
 import 'ui_number_formatter.dart';
@@ -109,7 +110,7 @@ class BlurBasedOnPrivateMode extends StatelessWidget {
   Widget build(BuildContext context) {
     return StreamBuilder(
       stream: PrivateModeService.instance.privateModeStream,
-      initialData: false,
+      initialData: appStateSettings[SettingKey.privateModeAtLaunch] == '1',
       builder: (context, snapshot) {
         final isInPrivateMode = snapshot.data ?? false;
 

--- a/lib/core/utils/debouncer.dart
+++ b/lib/core/utils/debouncer.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+class Debouncer {
+  final int milliseconds;
+  Timer? _timer;
+  Debouncer({required this.milliseconds});
+  void run(VoidCallback action) {
+    if (_timer != null) {
+      _timer!.cancel();
+    }
+    _timer = Timer(Duration(milliseconds: milliseconds), action);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:drift/drift.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -9,6 +8,7 @@ import 'package:monekin/app/onboarding/intro.page.dart';
 import 'package:monekin/core/database/services/app-data/app_data_service.dart';
 import 'package:monekin/core/database/services/user-setting/private_mode_service.dart';
 import 'package:monekin/core/database/services/user-setting/user_setting_service.dart';
+import 'package:monekin/core/database/services/user-setting/utils/get_theme_from_string.dart';
 import 'package:monekin/core/presentation/responsive/breakpoints.dart';
 import 'package:monekin/core/presentation/theme.dart';
 import 'package:monekin/core/routes/root_navigator_observer.dart';
@@ -19,15 +19,39 @@ import 'package:monekin/i18n/translations.g.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await PrivateModeService.instance.initializePrivateMode();
   await UserSettingService.instance.initializeSettings();
 
-  runApp(const MonekinAppEntryPoint());
+  PrivateModeService.instance
+      .setPrivateMode(appStateSettings[SettingKey.privateModeAtLaunch] == '1');
+
+  runApp(InitializeApp(key: appStateKey));
 }
 
 final GlobalKey<TabsPageState> tabsPageKey = GlobalKey();
 final GlobalKey<NavigationSidebarState> navigationSidebarKey = GlobalKey();
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+// ignore: library_private_types_in_public_api
+GlobalKey<_InitializeAppState> appStateKey = GlobalKey();
+
+class InitializeApp extends StatefulWidget {
+  const InitializeApp({super.key});
+
+  @override
+  State<InitializeApp> createState() => _InitializeAppState();
+}
+
+class _InitializeAppState extends State<InitializeApp> {
+  void refreshAppState() {
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // ignore: prefer_const_constructors
+    return MonekinAppEntryPoint(key: const ValueKey('App Entry Point'));
+  }
+}
 
 class MonekinAppEntryPoint extends StatelessWidget {
   const MonekinAppEntryPoint({
@@ -36,78 +60,49 @@ class MonekinAppEntryPoint extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Logger.printDebug("------------------ APP ENTRY POINT ------------------");
+    Logger.printDebug('------------------ APP ENTRY POINT ------------------');
 
-    return StreamBuilder(
-        stream: UserSettingService.instance.getSettings((p0) =>
-            p0.settingKey.equalsValue(SettingKey.appLanguage) |
-            p0.settingKey.equalsValue(SettingKey.themeMode) |
-            p0.settingKey.equalsValue(SettingKey.amoledMode) |
-            p0.settingKey.equalsValue(SettingKey.accentColor)),
-        builder: (context, snapshot) {
-          Logger.printDebug('Finding initial user settings...');
+    final lang = appStateSettings[SettingKey.appLanguage];
 
-          if (!snapshot.hasData) {
-            return Container();
-          }
+    if (lang != null) {
+      Logger.printDebug('App language found. Setting the locale to `$lang`...');
+      LocaleSettings.setLocaleRaw(lang);
+    } else {
+      Logger.printDebug(
+          'App language not found. Setting the user device language...');
 
-          final userSettings = snapshot.data!;
+      LocaleSettings.useDeviceLocale();
 
-          final lang = userSettings
-              .firstWhere(
-                  (element) => element.settingKey == SettingKey.appLanguage)
-              .settingValue;
+      // We have nothing to worry here since the useDeviceLocale() func will set the default lang (english in our case) if
+      // the user is using a non-supported language in his device
 
-          if (lang != null) {
-            Logger.printDebug(
-                'App language found. Setting the locale to `$lang`...');
-            LocaleSettings.setLocaleRaw(lang);
-          } else {
-            Logger.printDebug(
-                'App language not found. Setting the user device language...');
+      UserSettingService.instance
+          .setSetting(
+            SettingKey.appLanguage,
+            LocaleSettings.currentLocale.languageTag,
+          )
+          .then((value) => null);
+    }
 
-            LocaleSettings.useDeviceLocale();
+    return TranslationProvider(
+      child: StreamBuilder(
+          stream: AppDataService.instance
+              .getAppDataItem(AppDataKey.introSeen)
+              .map((event) => event == '1'),
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return Container();
+            }
 
-            // We have nothing to worry here since the useDeviceLocale() func will set the default lang (english in our case) if
-            // the user is using a non-supported language in his device
-
-            UserSettingService.instance
-                .setSetting(
-                  SettingKey.appLanguage,
-                  LocaleSettings.currentLocale.languageTag,
-                )
-                .then((value) => null);
-          }
-
-          return TranslationProvider(
-            child: StreamBuilder(
-                stream: AppDataService.instance
-                    .getAppDataItem(AppDataKey.introSeen)
-                    .map((event) => event == '1'),
-                builder: (context, snapshot) {
-                  if (!snapshot.hasData) {
-                    return Container();
-                  }
-
-                  return MaterialAppContainer(
-                    introSeen: snapshot.data!,
-                    amoledMode: userSettings
-                            .firstWhere((element) =>
-                                element.settingKey == SettingKey.amoledMode)
-                            .settingValue! ==
-                        '1',
-                    accentColor: userSettings
-                        .firstWhere((element) =>
-                            element.settingKey == SettingKey.accentColor)
-                        .settingValue!,
-                    themeMode: ThemeMode.values.byName(userSettings
-                        .firstWhere((element) =>
-                            element.settingKey == SettingKey.themeMode)
-                        .settingValue!),
-                  );
-                }),
-          );
-        });
+            return MaterialAppContainer(
+              introSeen: snapshot.data!,
+              amoledMode: appStateSettings[SettingKey.amoledMode]! == '1',
+              accentColor: appStateSettings[SettingKey.accentColor]!,
+              themeMode:
+                  getThemeFromString(appStateSettings[SettingKey.themeMode]!),
+            );
+          }),
+    );
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await PrivateModeService.instance.initializePrivateMode();
+  await UserSettingService.instance.initializeSettings();
 
   runApp(const MonekinAppEntryPoint());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,8 @@ import 'package:monekin/i18n/translations.g.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await UserSettingService.instance.initializeSettings();
+  await UserSettingService.instance.initializeGlobalStateMap();
+  await AppDataService.instance.initializeGlobalStateMap();
 
   PrivateModeService.instance
       .setPrivateMode(appStateSettings[SettingKey.privateModeAtLaunch] == '1');
@@ -77,7 +78,7 @@ class MonekinAppEntryPoint extends StatelessWidget {
       // the user is using a non-supported language in his device
 
       UserSettingService.instance
-          .setSetting(
+          .setItem(
             SettingKey.appLanguage,
             LocaleSettings.currentLocale.languageTag,
           )

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -86,28 +86,15 @@ class MonekinAppEntryPoint extends StatelessWidget {
     }
 
     return TranslationProvider(
-      child: StreamBuilder(
-          stream: AppDataService.instance
-              .getAppDataItem(AppDataKey.introSeen)
-              .map((event) => event == '1'),
-          builder: (context, snapshot) {
-            if (!snapshot.hasData) {
-              return Container();
-            }
-
-            return MaterialAppContainer(
-              introSeen: snapshot.data!,
-              amoledMode: appStateSettings[SettingKey.amoledMode]! == '1',
-              accentColor: appStateSettings[SettingKey.accentColor]!,
-              themeMode:
-                  getThemeFromString(appStateSettings[SettingKey.themeMode]!),
-            );
-          }),
+      child: MaterialAppContainer(
+        introSeen: appStateData[AppDataKey.introSeen] == '1',
+        amoledMode: appStateSettings[SettingKey.amoledMode]! == '1',
+        accentColor: appStateSettings[SettingKey.accentColor]!,
+        themeMode: getThemeFromString(appStateSettings[SettingKey.themeMode]!),
+      ),
     );
   }
 }
-
-int refresh = 1;
 
 class MaterialAppContainer extends StatelessWidget {
   const MaterialAppContainer(
@@ -132,7 +119,6 @@ class MaterialAppContainer extends StatelessWidget {
         builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
       return MaterialApp(
         title: 'Monekin',
-        key: ValueKey(refresh),
         debugShowCheckedModeBanner: false,
         locale: TranslationProvider.of(context).flutterLocale,
         scrollBehavior: ScrollBehaviorOverride(),


### PR DESCRIPTION
This PR allows Monekin to get all the user settings and the user app data before app launches, saving the state of this data and using it where needed, without the need of querying it again from the database. 

This allows performance improvements in many different places of the app and also fixes #246.