### PR TITLE
Fix/renderoverflex error

### DIFF
--- a/lib/app/home/dashboard.page.dart
+++ b/lib/app/home/dashboard.page.dart
@@ -139,29 +139,32 @@ class _DashboardPageState extends State<DashboardPage> {
                           StreamBuilder(
                               stream: AccountService.instance.getAccounts(),
                               builder: (context, accounts) {
-                                return Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    totalBalanceIndicator(
-                                        context, accounts, accountService),
-                                    Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        IncomeOrExpenseCard(
-                                          type: TransactionType.E,
-                                          startDate: dateRangeService.startDate,
-                                          endDate: dateRangeService.endDate,
-                                        ),
-                                        IncomeOrExpenseCard(
-                                          type: TransactionType.I,
-                                          startDate: dateRangeService.startDate,
-                                          endDate: dateRangeService.endDate,
-                                        ),
-                                      ],
-                                    ),
-                                  ],
+                                return SingleChildScrollView(
+                                  scrollDirection: Axis.horizontal,
+                                  child: Row(
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      totalBalanceIndicator(
+                                          context, accounts, accountService),
+                                      Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          IncomeOrExpenseCard(
+                                            type: TransactionType.E,
+                                            startDate: dateRangeService.startDate,
+                                            endDate: dateRangeService.endDate,
+                                          ),
+                                          IncomeOrExpenseCard(
+                                            type: TransactionType.I,
+                                            startDate: dateRangeService.startDate,
+                                            endDate: dateRangeService.endDate,
+                                          ),
+                                        ],
+                                      ),
+                                    ],
+                                  ),
                                 );
                               })
                         ]),


### PR DESCRIPTION
This PR fixes a small renderoverflex error in the dashboard when entering a bigger amount.

Reference image of error:

![s1](https://github.com/user-attachments/assets/26c500d5-0d14-46c9-81cc-2a6fc30fa623)
