### PR TITLE
Display compact currencies in some places to avoid UI overflows

### DIFF
--- a/lib/app/home/widgets/dashboard_cards.dart
+++ b/lib/app/home/widgets/dashboard_cards.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:monekin/app/stats/stats_page.dart';
+import 'package:monekin/app/stats/widgets/balance_bar_chart.dart';
+import 'package:monekin/app/stats/widgets/finance_health/finance_health_main_info.dart';
+import 'package:monekin/app/stats/widgets/fund_evolution_line_chart.dart';
+import 'package:monekin/app/stats/widgets/movements_distribution/chart_by_categories.dart';
+import 'package:monekin/core/models/date-utils/date_period_state.dart';
+import 'package:monekin/core/presentation/responsive/breakpoints.dart';
+import 'package:monekin/core/presentation/responsive/responsive_row_column.dart';
+import 'package:monekin/core/presentation/widgets/card_with_header.dart';
+import 'package:monekin/core/presentation/widgets/transaction_filter/transaction_filters.dart';
+import 'package:monekin/core/routes/route_utils.dart';
+import 'package:monekin/core/services/finance_health_service.dart';
+import 'package:monekin/i18n/translations.g.dart';
+
+class DashboardCards extends StatelessWidget {
+  const DashboardCards({
+    super.key,
+    required this.dateRangeService,
+  });
+
+  final DatePeriodState dateRangeService;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Translations.of(context);
+
+    return ResponsiveRowColumn.withSymetricSpacing(
+      direction: BreakPoint.of(context).isLargerThan(BreakpointID.md)
+          ? Axis.horizontal
+          : Axis.vertical,
+      rowCrossAxisAlignment: CrossAxisAlignment.start,
+      spacing: 16,
+      children: [
+        ResponsiveRowColumnItem(
+          rowFit: FlexFit.tight,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CardWithHeader(
+                title: t.financial_health.display,
+                footer: CardFooterWithSingleButton(
+                  onButtonClick: () => RouteUtils.pushRoute(
+                    context,
+                    StatsPage(
+                        dateRangeService: dateRangeService, initialIndex: 0),
+                  ),
+                ),
+                bodyPadding: const EdgeInsets.all(16),
+                body: StreamBuilder(
+                  stream: FinanceHealthService().getHealthyValue(
+                    filters: TransactionFilters(
+                      minDate: dateRangeService.startDate,
+                      maxDate: dateRangeService.endDate,
+                    ),
+                  ),
+                  builder: (context, snapshot) {
+                    if (!snapshot.hasData) {
+                      return const LinearProgressIndicator();
+                    }
+
+                    final financeHealthData = snapshot.data!;
+
+                    return FinanceHealthMainInfo(
+                        financeHealthData: financeHealthData);
+                  },
+                ),
+              ),
+              const SizedBox(height: 16),
+              CardWithHeader(
+                title: t.stats.by_categories,
+                body: ChartByCategories(datePeriodState: dateRangeService),
+                footer: CardFooterWithSingleButton(
+                  onButtonClick: () => RouteUtils.pushRoute(
+                    context,
+                    StatsPage(
+                        dateRangeService: dateRangeService, initialIndex: 1),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        ResponsiveRowColumnItem(
+          rowFit: FlexFit.tight,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CardWithHeader(
+                title: t.stats.balance_evolution,
+                bodyPadding: const EdgeInsets.all(16),
+                body: FundEvolutionLineChart(dateRange: dateRangeService),
+                footer: CardFooterWithSingleButton(onButtonClick: () {
+                  RouteUtils.pushRoute(
+                    context,
+                    StatsPage(
+                        dateRangeService: dateRangeService, initialIndex: 2),
+                  );
+                }),
+              ),
+              const SizedBox(height: 16),
+              CardWithHeader(
+                title: t.stats.by_periods,
+                bodyPadding:
+                    const EdgeInsets.only(bottom: 12, top: 24, right: 16),
+                body: BalanceBarChart(
+                  dateRange: dateRangeService,
+                  filters: TransactionFilters(
+                    minDate: dateRangeService.startDate,
+                    maxDate: dateRangeService.endDate,
+                  ),
+                ),
+                footer: CardFooterWithSingleButton(onButtonClick: () {
+                  RouteUtils.pushRoute(
+                    context,
+                    StatsPage(
+                        dateRangeService: dateRangeService, initialIndex: 3),
+                  );
+                }),
+              )
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/app/home/widgets/horizontal_scrollable_account_list.dart
+++ b/lib/app/home/widgets/horizontal_scrollable_account_list.dart
@@ -92,6 +92,8 @@ class HorizontalScrollableAccountList extends StatelessWidget {
                                             return CurrencyDisplayer(
                                               amountToConvert: snapshot.data!,
                                               currency: account.currency,
+                                              compactView:
+                                                  snapshot.data! >= 10000000,
                                               integerStyle: Theme.of(context)
                                                   .textTheme
                                                   .titleMedium!

--- a/lib/app/home/widgets/income_or_expense_card.dart
+++ b/lib/app/home/widgets/income_or_expense_card.dart
@@ -67,6 +67,8 @@ class IncomeOrExpenseCard extends StatelessWidget {
 
                     return CurrencyDisplayer(
                       amountToConvert: snapshot.data!.abs(),
+                      compactView: true,
+                      showDecimals: false,
                       integerStyle: TextStyle(
                           fontSize: 18,
                           color: Theme.of(context)

--- a/lib/app/transactions/recurrent_transactions_page.dart
+++ b/lib/app/transactions/recurrent_transactions_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:monekin/app/transactions/widgets/transaction_list.dart';
 import 'package:monekin/core/database/services/transaction/transaction_service.dart';
 import 'package:monekin/core/models/date-utils/periodicity.dart';
+import 'package:monekin/core/presentation/responsive/breakpoints.dart';
 import 'package:monekin/core/presentation/widgets/no_results.dart';
 import 'package:monekin/core/presentation/widgets/number_ui_formatters/currency_displayer.dart';
 import 'package:monekin/core/presentation/widgets/transaction_filter/transaction_filters.dart';
@@ -125,6 +126,12 @@ class _RecurrentTransactionPageState extends State<RecurrentTransactionPage> {
                               builder: (context, snapshot) {
                                 return CurrencyDisplayer(
                                   amountToConvert: snapshot.data!,
+                                  compactView: snapshot.data! <= 10000000000 &&
+                                          BreakPoint.of(context)
+                                              .isLargerOrEqualTo(
+                                                  BreakpointID.xl)
+                                      ? false
+                                      : true,
                                   integerStyle:
                                       Theme.of(context).textTheme.titleLarge!,
                                 );

--- a/lib/core/presentation/responsive/app_breakpoints.dart
+++ b/lib/core/presentation/responsive/app_breakpoints.dart
@@ -1,7 +1,7 @@
 import 'package:monekin/core/presentation/responsive/breakpoints.dart';
 
 final Set<BreakPoint> appBreakPoints = {
-  const BreakPoint(BreakpointID.xs, width: double.infinity),
+  const BreakPoint(BreakpointID.xs, width: 400),
   const BreakPoint(BreakpointID.sm, width: 540),
   const BreakPoint(BreakpointID.md, width: 720),
   const BreakPoint(BreakpointID.lg, width: 960),

--- a/lib/core/presentation/widgets/number_ui_formatters/currency_displayer.dart
+++ b/lib/core/presentation/widgets/number_ui_formatters/currency_displayer.dart
@@ -25,6 +25,7 @@ class CurrencyDisplayer extends StatelessWidget {
     this.decimalsStyle,
     this.currencyStyle,
     this.followPrivateMode = true,
+    this.compactView = false,
   });
 
   final double amountToConvert;
@@ -51,6 +52,7 @@ class CurrencyDisplayer extends StatelessWidget {
   final TextStyle? currencyStyle;
 
   final bool showDecimals;
+  final bool compactView;
 
   Widget _amountDisplayer(
     BuildContext context, {
@@ -63,6 +65,7 @@ class CurrencyDisplayer extends StatelessWidget {
       integerStyle: integerStyle,
       decimalsStyle: decimalsStyle,
       currencyStyle: currencyStyle,
+      compactView: compactView,
     ).getTextWidget(context);
   }
 


### PR DESCRIPTION
This PR introduces compact number formatting (e.g., 1.2M, 23.3k) to address overflow issues observed in various parts of the UI. These issues were particularly prevalent with currencies experiencing high inflation rates, where large amounts caused layout problems. Compact formatting ensures better readability and prevents visual inconsistencies.

Also, and again to address overflow issues, the income and expense indicator of the dasboard header have been moved below the total balance amount for mobile or small devices. This result in a similar UI to what we had in the initial versions of the app.