### PR TITLE
Lost tags when cloning or editing transactions

### DIFF
--- a/lib/app/categories/form/category_form_functions.dart
+++ b/lib/app/categories/form/category_form_functions.dart
@@ -116,7 +116,7 @@ class CategoryFormFunctions {
                     includeParentCategoriesInSearch: true))
             .first) {
           futures.add(
-            TransactionService.instance.insertOrUpdateTransaction(
+            TransactionService.instance.updateTransaction(
                 tr.copyWith(categoryID: drift.Value(selCategory.id))),
           );
         }

--- a/lib/app/transactions/form/transaction_form.page.dart
+++ b/lib/app/transactions/form/transaction_form.page.dart
@@ -258,57 +258,80 @@ class _TransactionFormPageState extends State<TransactionFormPage>
 
     final newTrID = widget.transactionToEdit?.id ?? generateUUID();
 
-    TransactionService.instance
-        .insertOrUpdateTransaction(
-      TransactionInDB(
-        id: newTrID,
-        date: date,
-        type: transactionType,
-        accountID: fromAccount!.id,
-        value: transactionType == TransactionType.E
-            ? transactionValue * -1
-            : transactionValue,
-        isHidden: false,
-        status: date.compareTo(DateTime.now()) > 0
-            ? TransactionStatus.pending
-            : status,
-        notes: notesController.text.isEmpty ? null : notesController.text,
-        title: titleController.text.isEmpty ? null : titleController.text,
-        intervalEach: recurrentRule.intervalEach,
-        intervalPeriod: recurrentRule.intervalPeriod,
-        endDate: recurrentRule.ruleRecurrentLimit?.endDate,
-        remainingTransactions:
-            recurrentRule.ruleRecurrentLimit?.remainingIterations,
-        valueInDestiny:
-            transactionType.isTransfer ? valueInDestinyToNumber : null,
-        categoryID:
-            transactionType.isIncomeOrExpense ? selectedCategory?.id : null,
-        receivingAccountID:
-            transactionType.isTransfer ? transferAccount?.id : null,
-      ),
-    )
-        .then((value) {
+    final transactionToPost = TransactionInDB(
+      id: newTrID,
+      date: date,
+      type: transactionType,
+      accountID: fromAccount!.id,
+      value: transactionType == TransactionType.E
+          ? transactionValue * -1
+          : transactionValue,
+      isHidden: false,
+      status: date.compareTo(DateTime.now()) > 0
+          ? TransactionStatus.pending
+          : status,
+      notes: notesController.text.isEmpty ? null : notesController.text,
+      title: titleController.text.isEmpty ? null : titleController.text,
+      intervalEach: recurrentRule.intervalEach,
+      intervalPeriod: recurrentRule.intervalPeriod,
+      endDate: recurrentRule.ruleRecurrentLimit?.endDate,
+      remainingTransactions:
+          recurrentRule.ruleRecurrentLimit?.remainingIterations,
+      valueInDestiny:
+          transactionType.isTransfer ? valueInDestinyToNumber : null,
+      categoryID:
+          transactionType.isIncomeOrExpense ? selectedCategory?.id : null,
+      receivingAccountID:
+          transactionType.isTransfer ? transferAccount?.id : null,
+    );
+
+    Future<int> postCall =
+        TransactionService.instance.updateTransaction(transactionToPost);
+
+    if (!isEditMode) {
+      postCall =
+          TransactionService.instance.insertTransaction(transactionToPost);
+    }
+
+    postCall.then((value) async {
       final db = AppDB.instance;
 
-      Future.wait(
-        [
-          for (final tag in tags)
-            if (widget.transactionToEdit != null &&
-                widget.transactionToEdit!.tags
-                    .any((element) => element.id == tag.id))
-              (db.delete(db.transactionTags)
-                    ..where((tbl) => tbl.tagID.isValue(tag.id)))
-                  .go()
-            else
-              db
-                  .into(db.transactionTags)
-                  .insert(TransactionTag(transactionID: newTrID, tagID: tag.id))
-        ],
-      ).then((value) {
+      final existingTags = widget.transactionToEdit?.tags ?? [];
+
+      // Tags to remove: present in the current transaction but not in the new tags list
+      final tagsToRemove = existingTags
+          .where((existingTag) =>
+              !tags.any((newTag) => newTag.id == existingTag.id))
+          .toList();
+
+      // Tags to add: present in the new tags list but not in the current transaction
+      final tagsToAdd = tags
+          .where((newTag) =>
+              !existingTags.any((existingTag) => existingTag.id == newTag.id))
+          .toList();
+
+      try {
+        // Remove tags
+        for (final tag in tagsToRemove) {
+          await (db.delete(db.transactionTags)
+                ..where((tbl) =>
+                    tbl.tagID.isValue(tag.id) &
+                    tbl.transactionID.isValue(newTrID)))
+              .go();
+        }
+
+        // Add new tags
+        for (final tag in tagsToAdd) {
+          await db.into(db.transactionTags).insert(
+                TransactionTag(transactionID: newTrID, tagID: tag.id),
+              );
+        }
+
         onSuccess();
-      }).catchError((error) {
+      } catch (error) {
+        Navigator.pop(context);
         scMessenger.showSnackBar(SnackBar(content: Text(error.toString())));
-      });
+      }
     }).catchError((error) {
       scMessenger.showSnackBar(SnackBar(content: Text(error.toString())));
     });

--- a/lib/app/transactions/transaction_details.page.dart
+++ b/lib/app/transactions/transaction_details.page.dart
@@ -91,7 +91,7 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
                   const nullValue = drift.Value(null);
 
                   TransactionService.instance
-                      .insertOrUpdateTransaction(transaction.copyWith(
+                      .updateTransaction(transaction.copyWith(
                     date: datetime,
                     status: nullValue,
                     id: newId,
@@ -133,7 +133,7 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
                           .ruleRecurrentLimit!.remainingIterations;
 
                       TransactionService.instance
-                          .insertOrUpdateTransaction(
+                          .updateTransaction(
                         transaction.copyWith(
                             date: transaction.followingDateToNext,
                             remainingTransactions: remainingIterations != null
@@ -222,7 +222,7 @@ class _TransactionDetailsPageState extends State<TransactionDetailsPage> {
           transaction.recurrentInfo.ruleRecurrentLimit!.remainingIterations;
 
       TransactionService.instance
-          .insertOrUpdateTransaction(transaction.copyWith(
+          .updateTransaction(transaction.copyWith(
               date: transaction.followingDateToNext,
               remainingTransactions: remainingIterations != null
                   ? drift.Value(remainingIterations - 1)

--- a/lib/app/transactions/widgets/bulk_edit_transaction_modal.dart
+++ b/lib/app/transactions/widgets/bulk_edit_transaction_modal.dart
@@ -47,7 +47,7 @@ class BulkEditTransactionModal extends StatelessWidget {
                     context,
                     futures: transactionsToEdit.map(
                       (e) => TransactionService.instance
-                          .insertOrUpdateTransaction(e.copyWith(date: date)),
+                          .updateTransaction(e.copyWith(date: date)),
                     ),
                   );
                 },
@@ -71,9 +71,8 @@ class BulkEditTransactionModal extends StatelessWidget {
                     performUpdates(
                       context,
                       futures: transactionsToEdit.map(
-                        (e) => TransactionService.instance
-                            .insertOrUpdateTransaction(
-                                e.copyWith(categoryID: Value(modalRes.id))),
+                        (e) => TransactionService.instance.updateTransaction(
+                            e.copyWith(categoryID: Value(modalRes.id))),
                       ),
                     );
                   },
@@ -95,7 +94,7 @@ class BulkEditTransactionModal extends StatelessWidget {
                       context,
                       futures: transactionsToEdit.map(
                         (e) => TransactionService.instance
-                            .insertOrUpdateTransaction(e.copyWith(
+                            .updateTransaction(e.copyWith(
                           status: Value(modalRes.result),
                         )),
                       ),

--- a/lib/core/database/services/transaction/transaction_service.dart
+++ b/lib/core/database/services/transaction/transaction_service.dart
@@ -42,16 +42,14 @@ class TransactionService {
     return toReturn;
   }
 
-  Future<int> insertOrUpdateTransaction(TransactionInDB transaction) async {
-    final toReturn = await db
-        .into(db.transactions)
-        .insert(transaction, mode: InsertMode.insertOrReplace);
+  Future<int> updateTransaction(TransactionInDB transaction) async {
+    final toReturn = await db.update(db.transactions).replace(transaction);
 
     // To update the getAccountsData() function results
     // TODO: Check why we need this. The function already listen to changes in the transactions table
     db.markTablesUpdated([db.accounts]);
 
-    return toReturn;
+    return toReturn ? 1 : 0;
   }
 
   Future<int> deleteTransaction(String transactionId) {

--- a/lib/core/models/transaction/transaction.dart
+++ b/lib/core/models/transaction/transaction.dart
@@ -175,10 +175,11 @@ class MoneyTransaction extends TransactionInDB {
     baseValue = baseValue / intervalEachDivider;
 
     if (recurrentInfo.intervalPeriod != null) {
-      return baseValue * Periodicity.getConversionFactor(
-        recurrentInfo.intervalPeriod!,
-        periodicity,
-      );
+      return baseValue *
+          Periodicity.getConversionFactor(
+            recurrentInfo.intervalPeriod!,
+            periodicity,
+          );
     }
 
     throw Exception('We could not calculate this value');


### PR DESCRIPTION
## Pull request (PR) checklist

Please check if your pull request fulfills the following requirements:

<!--💡 Tip: Tick checkboxes like this: [x] 💡-->

- [X] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [X] I confirm that I've run the code locally and everything works as expected.

## What's changed?

Fixed the bug that caused transaction tags to be lost when editing or cloning a transaction. A mix of circumstances was happening here:

1. The logic in the code to add/remove tags to already existing transactions was incorrect
2. When cloning transactions, the code to add their tags was missing
3. The most important of all, when updating a transaction, what was actually being done was deleting it and adding it again. This is due to the way drift's `InsertMode.insertOrReplace` mode works. When having an ON UPDATE CASCADE on the `transactionTags` table, the tags were being removed when performing this operation.

## Does this PR close any GitHub issues? (do not delete)

No
