### PR TITLE
Fund evolution chart without info in "always" date period

### DIFF
--- a/lib/app/stats/utils/common_axis_titles.dart
+++ b/lib/app/stats/utils/common_axis_titles.dart
@@ -1,0 +1,5 @@
+import 'package:fl_chart/fl_chart.dart';
+
+AxisTitles get noAxisTitles => const AxisTitles(
+      sideTitles: SideTitles(showTitles: false),
+    );

--- a/lib/app/stats/widgets/fund_evolution_line_chart.dart
+++ b/lib/app/stats/widgets/fund_evolution_line_chart.dart
@@ -1,6 +1,8 @@
+import 'package:collection/collection.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:monekin/app/stats/utils/common_axis_titles.dart';
 import 'package:monekin/core/database/services/account/account_service.dart';
 import 'package:monekin/core/database/services/currency/currency_service.dart';
 import 'package:monekin/core/extensions/color.extensions.dart';
@@ -36,22 +38,21 @@ class FundEvolutionLineChart extends StatelessWidget {
 
   final TransactionFilters filters;
 
-  Stream<LineChartDataItem?> getEvolutionData() {
-    if (dateRange.startDate == null || dateRange.endDate == null) {
+  Stream<LineChartDataItem?> getEvolutionData(DateTimeRange? timeRange) {
+    if (timeRange == null) {
       return Stream.value(null);
     }
 
     List<Stream<double>> balance = [];
     List<String> labels = [];
 
-    DateTime currentDay = DateTime(dateRange.startDate!.year,
-        dateRange.startDate!.month, dateRange.startDate!.day);
+    DateTime currentDay = DateTime(
+        timeRange.start.year, timeRange.start.month, timeRange.start.day);
 
     final dayRange =
-        (dateRange.endDate!.difference(dateRange.startDate!).inDays / 100)
-            .ceil();
+        (timeRange.end.difference(timeRange.start).inDays / 100).ceil();
 
-    while (currentDay.compareTo(dateRange.endDate!) < 0) {
+    while (currentDay.compareTo(timeRange.end) < 0) {
       labels.add(currentDay.year == currentYear
           ? DateFormat.MMMMd().format(currentDay)
           : DateFormat.yMMMd().format(currentDay));
@@ -74,103 +75,105 @@ class FundEvolutionLineChart extends StatelessWidget {
 
     final t = Translations.of(context);
 
-    return Column(
-      children: [
-        if (showBalanceHeader)
-          StreamBuilder(
-            stream: filters.accounts(),
-            builder: (context, accountsSnapshot) {
-              if (!accountsSnapshot.hasData) {
-                return Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text('Final balance - ${dateRange.getText(context)}',
-                        style: const TextStyle(fontSize: 12)),
-                    const Skeleton(width: 70, height: 40),
-                    const Skeleton(width: 30, height: 14),
-                  ],
-                );
-              } else {
-                final accounts = accountsSnapshot.data!;
+    return StreamBuilder(
+        stream: filters.accounts(),
+        builder: (context, accountsSnapshot) {
+          return Column(
+            children: [
+              if (showBalanceHeader)
+                Builder(
+                  builder: (context) {
+                    if (!accountsSnapshot.hasData) {
+                      return Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text('Final balance - ${dateRange.getText(context)}',
+                              style: const TextStyle(fontSize: 12)),
+                          const Skeleton(width: 70, height: 40),
+                          const Skeleton(width: 30, height: 14),
+                        ],
+                      );
+                    }
 
-                return Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(t.stats.final_balance,
-                            style: const TextStyle(fontSize: 12)),
-                        StreamBuilder(
-                            stream: accountService.getAccountsMoney(
-                              accountIds: accounts.map((e) => e.id),
-                              trFilters: filters,
-                              date: dateRange.endDate,
-                            ),
-                            builder: (context, snapshot) {
-                              if (!snapshot.hasData) {
-                                return const Skeleton(width: 70, height: 40);
-                              }
+                    final accounts = accountsSnapshot.data!;
 
-                              return CurrencyDisplayer(
-                                  amountToConvert: snapshot.data!,
-                                  integerStyle: Theme.of(context)
-                                      .textTheme
-                                      .headlineSmall!);
-                            }),
-                      ],
-                    ),
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      crossAxisAlignment: CrossAxisAlignment.end,
+                    return Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text(
-                          t.stats.compared_to_previous_period,
-                          style: const TextStyle(fontSize: 12),
+                        Column(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(t.stats.final_balance,
+                                style: const TextStyle(fontSize: 12)),
+                            StreamBuilder(
+                                stream: accountService.getAccountsMoney(
+                                  accountIds: accounts.map((e) => e.id),
+                                  trFilters: filters,
+                                  date: dateRange.endDate,
+                                ),
+                                builder: (context, snapshot) {
+                                  if (!snapshot.hasData) {
+                                    return const Skeleton(
+                                        width: 70, height: 40);
+                                  }
+
+                                  return CurrencyDisplayer(
+                                      amountToConvert: snapshot.data!,
+                                      integerStyle: Theme.of(context)
+                                          .textTheme
+                                          .headlineSmall!);
+                                }),
+                          ],
                         ),
-                        StreamBuilder(
-                            stream: accountService.getAccountsMoneyVariation(
-                              accounts: accounts,
-                              startDate: dateRange.startDate,
-                              endDate: dateRange.endDate,
-                              convertToPreferredCurrency: true,
+                        Column(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              t.stats.compared_to_previous_period,
+                              style: const TextStyle(fontSize: 12),
                             ),
-                            builder: (context, snapshot) {
-                              if (!snapshot.hasData) {
-                                return const Skeleton(width: 52, height: 22);
-                              }
+                            StreamBuilder(
+                                stream:
+                                    accountService.getAccountsMoneyVariation(
+                                  accounts: accounts,
+                                  startDate: dateRange.startDate,
+                                  endDate: dateRange.endDate,
+                                  convertToPreferredCurrency: true,
+                                ),
+                                builder: (context, snapshot) {
+                                  if (!snapshot.hasData) {
+                                    return const Skeleton(
+                                        width: 52, height: 22);
+                                  }
 
-                              return TrendingValue(
-                                percentage: snapshot.data!,
-                                filled: false,
-                                fontWeight: Theme.of(context)
-                                    .textTheme
-                                    .headlineSmall!
-                                    .fontWeight!,
-                                fontSize: Theme.of(context)
-                                    .textTheme
-                                    .headlineSmall!
-                                    .fontSize!,
-                                outlined: false,
-                              );
-                            })
+                                  return TrendingValue(
+                                    percentage: snapshot.data!,
+                                    filled: false,
+                                    fontWeight: Theme.of(context)
+                                        .textTheme
+                                        .headlineSmall!
+                                        .fontWeight!,
+                                    fontSize: Theme.of(context)
+                                        .textTheme
+                                        .headlineSmall!
+                                        .fontSize!,
+                                    outlined: false,
+                                  );
+                                })
+                          ],
+                        )
                       ],
-                    )
-                  ],
-                );
-              }
-            },
-          ),
-        const SizedBox(height: 24),
-        SizedBox(
-          height: 260,
-          child: StreamBuilder(
-              stream: getEvolutionData(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const Column(
+                    );
+                  },
+                ),
+              const SizedBox(height: 24),
+              SizedBox(
+                height: 260,
+                child: Builder(builder: (context) {
+                  const loadingWidget = Column(
                     crossAxisAlignment: CrossAxisAlignment.center,
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
@@ -182,177 +185,217 @@ class FundEvolutionLineChart extends StatelessWidget {
                       ),
                     ],
                   );
-                }
 
-                final ultraLightBorderColor = isAppInLightBrightness(context)
-                    ? Colors.black12
-                    : Colors.white12;
+                  if (!accountsSnapshot.hasData) {
+                    return loadingWidget;
+                  }
 
-                return StreamBuilder(
-                    stream: CurrencyService.instance.getUserPreferredCurrency(),
-                    builder: (context, userCurrencySnapshot) {
-                      return Stack(
-                        children: [
-                          LineChart(LineChartData(
-                            gridData: FlGridData(
-                              show: true,
-                              drawVerticalLine: false,
-                              getDrawingHorizontalLine: (value) =>
-                                  defaultGridLine(value).copyWith(
-                                      color: ultraLightBorderColor,
-                                      strokeWidth: 0.5),
-                            ),
-                            lineTouchData: LineTouchData(
-                              enabled: snapshot.hasData,
-                              touchTooltipData: LineTouchTooltipData(
-                                tooltipMargin: -10,
-                                getTooltipColor: (spot) =>
-                                    Theme.of(context).colorScheme.surface,
-                                getTooltipItems: (touchedSpots) {
-                                  return touchedSpots.map((barSpot) {
-                                    final flSpot = barSpot;
-                                    if (flSpot.x == 0 || flSpot.x == 6) {
-                                      return null;
-                                    }
+                  final sortedAccounts = accountsSnapshot.data!
+                      .sorted((a, b) => a.date.compareTo(b.date));
 
-                                    return LineTooltipItem(
-                                        '${snapshot.data!.labels[flSpot.x.toInt()]} \n',
-                                        const TextStyle(fontSize: 12),
-                                        textAlign: TextAlign.start,
-                                        children: UINumberFormatter.currency(
-                                          currency: userCurrencySnapshot.data,
-                                          amountToConvert: snapshot
-                                              .data!.balance[flSpot.x.toInt()],
-                                          integerStyle: const TextStyle(
-                                            fontWeight: FontWeight.bold,
-                                            fontSize: 14,
-                                          ),
-                                        ).getTextSpanList(context));
-                                  }).toList();
-                                },
-                              ),
-                            ),
-                            minY: snapshot.hasData
-                                ? (snapshot.data!.balance.allItemsEqual()
-                                    ? snapshot.data!.balance.first - 10.2
-                                    : null)
-                                : 2,
-                            maxY: snapshot.hasData
-                                ? (snapshot.data!.balance.allItemsEqual()
-                                    ? snapshot.data!.balance.first + 10.2
-                                    : null)
-                                : 5,
-                            titlesData: FlTitlesData(
-                              show: true,
-                              rightTitles: const AxisTitles(
-                                  sideTitles: SideTitles(showTitles: false)),
-                              topTitles: const AxisTitles(
-                                  sideTitles: SideTitles(showTitles: false)),
-                              bottomTitles: const AxisTitles(
-                                  sideTitles: SideTitles(showTitles: false)),
-                              leftTitles: AxisTitles(
-                                sideTitles: SideTitles(
-                                  showTitles: snapshot.hasData,
-                                  reservedSize: 28,
-                                  getTitlesWidget: (value, meta) {
-                                    if (value == meta.max ||
-                                        value == meta.min) {
-                                      return Container();
-                                    }
+                  final chartDateRange = sortedAccounts.isEmpty
+                      ? dateRange.toDateTimeRange
+                      : DateTimeRange(
+                          start:
+                              dateRange.startDate ?? sortedAccounts.first.date,
+                          end: dateRange.endDate ?? DateTime.now(),
+                        );
 
-                                    return SideTitleWidget(
-                                      meta: meta,
-                                      child: BlurBasedOnPrivateMode(
-                                        child: Text(
-                                          meta.formattedValue,
-                                          maxLines: 1,
-                                          textAlign: TextAlign.end,
-                                          softWrap: false,
-                                          overflow: TextOverflow.visible,
-                                          style: const TextStyle(
-                                            fontSize: 10,
-                                            fontWeight: FontWeight.w300,
+                  return StreamBuilder(
+                      stream: getEvolutionData(chartDateRange),
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState ==
+                            ConnectionState.waiting) {
+                          return loadingWidget;
+                        }
+
+                        final ultraLightBorderColor =
+                            isAppInLightBrightness(context)
+                                ? Colors.black12
+                                : Colors.white12;
+
+                        return StreamBuilder(
+                            stream: CurrencyService.instance
+                                .getUserPreferredCurrency(),
+                            builder: (context, userCurrencySnapshot) {
+                              return Stack(
+                                children: [
+                                  LineChart(LineChartData(
+                                    gridData: FlGridData(
+                                      show: true,
+                                      drawVerticalLine: false,
+                                      getDrawingHorizontalLine: (value) =>
+                                          defaultGridLine(value).copyWith(
+                                              color: ultraLightBorderColor,
+                                              strokeWidth: 0.5),
+                                    ),
+                                    lineTouchData: LineTouchData(
+                                      enabled: snapshot.hasData,
+                                      touchTooltipData: LineTouchTooltipData(
+                                        tooltipMargin: -10,
+                                        getTooltipColor: (spot) =>
+                                            Theme.of(context)
+                                                .colorScheme
+                                                .surface,
+                                        getTooltipItems: (touchedSpots) {
+                                          return touchedSpots.map((barSpot) {
+                                            final flSpot = barSpot;
+                                            if (flSpot.x == 0 ||
+                                                flSpot.x == 6) {
+                                              return null;
+                                            }
+
+                                            return LineTooltipItem(
+                                                '${snapshot.data!.labels[flSpot.x.toInt()]} \n',
+                                                const TextStyle(fontSize: 12),
+                                                textAlign: TextAlign.start,
+                                                children:
+                                                    UINumberFormatter.currency(
+                                                  currency:
+                                                      userCurrencySnapshot.data,
+                                                  amountToConvert:
+                                                      snapshot.data!.balance[
+                                                          flSpot.x.toInt()],
+                                                  integerStyle: const TextStyle(
+                                                    fontWeight: FontWeight.bold,
+                                                    fontSize: 14,
+                                                  ),
+                                                ).getTextSpanList(context));
+                                          }).toList();
+                                        },
+                                      ),
+                                    ),
+                                    minY: snapshot.hasData
+                                        ? (snapshot.data!.balance
+                                                .allItemsEqual()
+                                            ? snapshot.data!.balance.first -
+                                                10.2
+                                            : null)
+                                        : 2,
+                                    maxY: snapshot.hasData
+                                        ? (snapshot.data!.balance
+                                                .allItemsEqual()
+                                            ? snapshot.data!.balance.first +
+                                                10.2
+                                            : null)
+                                        : 5,
+                                    titlesData: FlTitlesData(
+                                      show: true,
+                                      rightTitles: noAxisTitles,
+                                      topTitles: noAxisTitles,
+                                      bottomTitles: noAxisTitles,
+                                      leftTitles: AxisTitles(
+                                        sideTitles: SideTitles(
+                                          showTitles: snapshot.hasData,
+                                          reservedSize: 28,
+                                          getTitlesWidget: (value, meta) {
+                                            if (value == meta.max ||
+                                                value == meta.min) {
+                                              return Container();
+                                            }
+
+                                            return SideTitleWidget(
+                                              meta: meta,
+                                              child: BlurBasedOnPrivateMode(
+                                                child: Text(
+                                                  meta.formattedValue,
+                                                  maxLines: 1,
+                                                  textAlign: TextAlign.end,
+                                                  softWrap: false,
+                                                  overflow:
+                                                      TextOverflow.visible,
+                                                  style: const TextStyle(
+                                                    fontSize: 10,
+                                                    fontWeight: FontWeight.w300,
+                                                  ),
+                                                ),
+                                              ),
+                                            );
+                                          },
+                                        ),
+                                      ),
+                                    ),
+                                    borderData: FlBorderData(
+                                      show: false,
+                                      border: Border(
+                                        bottom: BorderSide(
+                                            color: ultraLightBorderColor,
+                                            width: 1),
+                                        right: BorderSide(
+                                            color: ultraLightBorderColor,
+                                            width: 1),
+                                      ),
+                                    ),
+                                    lineBarsData: [
+                                      LineChartBarData(
+                                        spots: snapshot.hasData
+                                            ? List.generate(
+                                                snapshot.data!.balance.length,
+                                                (index) => FlSpot(
+                                                    index.toDouble(),
+                                                    snapshot
+                                                        .data!.balance[index]))
+                                            : [
+                                                const FlSpot(0, 3),
+                                                const FlSpot(2.6, 2.2),
+                                                const FlSpot(4.9, 4.3),
+                                                const FlSpot(6.8, 3.1),
+                                                const FlSpot(8, 4),
+                                                const FlSpot(9.5, 3),
+                                                const FlSpot(11, 4),
+                                              ],
+                                        isCurved: true,
+                                        curveSmoothness:
+                                            snapshot.hasData ? 0.025 : 0.2,
+                                        color: snapshot.hasData
+                                            ? lineColor
+                                            : Colors.grey.withOpacity(0.2),
+                                        barWidth: 3,
+                                        isStrokeCapRound: true,
+                                        dotData: const FlDotData(show: false),
+                                        belowBarData: BarAreaData(
+                                          show: true,
+                                          applyCutOffY: true,
+                                          cutOffY: 0,
+                                          gradient: LinearGradient(
+                                            begin: Alignment.topCenter,
+                                            end: Alignment.bottomCenter,
+                                            colors: snapshot.hasData
+                                                ? [
+                                                    lineColor.withAlpha(100),
+                                                    lineColor.withAlpha(1)
+                                                  ]
+                                                : [
+                                                    Colors.grey,
+                                                    Colors.grey.lighten(0.3)
+                                                  ]
+                                                    .map((color) =>
+                                                        color.withOpacity(0.15))
+                                                    .toList(),
                                           ),
                                         ),
                                       ),
-                                    );
-                                  },
-                                ),
-                              ),
-                            ),
-                            borderData: FlBorderData(
-                              show: false,
-                              border: Border(
-                                bottom: BorderSide(
-                                    color: ultraLightBorderColor, width: 1),
-                                right: BorderSide(
-                                    color: ultraLightBorderColor, width: 1),
-                              ),
-                            ),
-                            lineBarsData: [
-                              LineChartBarData(
-                                spots: snapshot.hasData
-                                    ? List.generate(
-                                        snapshot.data!.balance.length,
-                                        (index) => FlSpot(index.toDouble(),
-                                            snapshot.data!.balance[index]))
-                                    : [
-                                        const FlSpot(0, 3),
-                                        const FlSpot(2.6, 2.2),
-                                        const FlSpot(4.9, 4.3),
-                                        const FlSpot(6.8, 3.1),
-                                        const FlSpot(8, 4),
-                                        const FlSpot(9.5, 3),
-                                        const FlSpot(11, 4),
-                                      ],
-                                isCurved: true,
-                                curveSmoothness: snapshot.hasData ? 0.025 : 0.2,
-                                color: snapshot.hasData
-                                    ? lineColor
-                                    : Colors.grey.withOpacity(0.2),
-                                barWidth: 3,
-                                isStrokeCapRound: true,
-                                dotData: const FlDotData(show: false),
-                                belowBarData: BarAreaData(
-                                  show: true,
-                                  applyCutOffY: true,
-                                  cutOffY: 0,
-                                  gradient: LinearGradient(
-                                    begin: Alignment.topCenter,
-                                    end: Alignment.bottomCenter,
-                                    colors: snapshot.hasData
-                                        ? [
-                                            lineColor.withAlpha(100),
-                                            lineColor.withAlpha(1)
-                                          ]
-                                        : [
-                                            Colors.grey,
-                                            Colors.grey.lighten(0.3)
-                                          ]
-                                            .map((color) =>
-                                                color.withOpacity(0.15))
-                                            .toList(),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          )),
-                          if (!snapshot.hasData)
-                            Positioned.fill(
-                              child: Align(
-                                  alignment: Alignment.center,
-                                  child: Text(
-                                    t.general.insufficient_data,
-                                    style:
-                                        Theme.of(context).textTheme.titleLarge,
+                                    ],
                                   )),
-                            ),
-                        ],
-                      );
-                    });
-              }),
-        ),
-      ],
-    );
+                                  if (!snapshot.hasData)
+                                    Positioned.fill(
+                                      child: Align(
+                                          alignment: Alignment.center,
+                                          child: Text(
+                                            t.general.insufficient_data,
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .titleLarge,
+                                          )),
+                                    ),
+                                ],
+                              );
+                            });
+                      });
+                }),
+              ),
+            ],
+          );
+        });
   }
 }

--- a/lib/app/stats/widgets/fund_evolution_line_chart.dart
+++ b/lib/app/stats/widgets/fund_evolution_line_chart.dart
@@ -6,6 +6,7 @@ import 'package:monekin/app/stats/utils/common_axis_titles.dart';
 import 'package:monekin/core/database/services/account/account_service.dart';
 import 'package:monekin/core/database/services/currency/currency_service.dart';
 import 'package:monekin/core/extensions/color.extensions.dart';
+import 'package:monekin/core/extensions/date.extensions.dart';
 import 'package:monekin/core/extensions/lists.extensions.dart';
 import 'package:monekin/core/models/date-utils/date_period_state.dart';
 import 'package:monekin/core/presentation/theme.dart';
@@ -46,8 +47,7 @@ class FundEvolutionLineChart extends StatelessWidget {
     List<Stream<double>> balance = [];
     List<String> labels = [];
 
-    DateTime currentDay = DateTime(
-        timeRange.start.year, timeRange.start.month, timeRange.start.day);
+    DateTime currentDay = timeRange.start.justDay();
 
     final dayRange =
         (timeRange.end.difference(timeRange.start).inDays / 100).ceil();

--- a/lib/core/database/services/account/account_service.dart
+++ b/lib/core/database/services/account/account_service.dart
@@ -194,6 +194,8 @@ class AccountService {
     DateTime? endDate,
     bool convertToPreferredCurrency = true,
   }) {
+    if (accounts.isEmpty) return Stream.value(0);
+
     endDate ??= DateTime.now();
     startDate ??= accounts.map((e) => e.date).min;
 


### PR DESCRIPTION
Fix a bug that was causing the evolution chart to crash if we select the "always" date period. From now on, the open date of the older account will be used when possible to display this chart.

## Pull request (PR) checklist

Please check if your pull request fulfills the following requirements:

<!--💡 Tip: Tick checkboxes like this: [x] 💡-->

- [X] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [X] I confirm that I've run the code locally and everything works as expected.

## Does this PR close any GitHub issues? (do not delete)

No