### PR TITLE
Avoid making a subcategory or merging with its own

### DIFF
--- a/lib/app/categories/form/category_form_functions.dart
+++ b/lib/app/categories/form/category_form_functions.dart
@@ -77,6 +77,7 @@ class CategoryFormFunctions {
       context,
       modal: CategoryPicker(
         categoryType: [category.type, CategoryType.B],
+        excludeCategoriesWithId: [category.id],
         selectedCategory: null,
       ),
     ).then((selCategory) {
@@ -164,6 +165,7 @@ class CategoryFormFunctions {
       modal: CategoryPicker(
         categoryType: [category.type, CategoryType.B],
         selectedCategory: null,
+        excludeCategoriesWithId: [category.id],
         showSubcategories: false,
       ),
     ).then((selCategory) {

--- a/lib/app/categories/selectors/category_picker.dart
+++ b/lib/app/categories/selectors/category_picker.dart
@@ -37,10 +37,14 @@ class CategoryPicker extends StatefulWidget {
     required this.selectedCategory,
     required this.categoryType,
     this.showSubcategories = true,
+    this.excludeCategoriesWithId = const [],
   }) : assert(categoryType.isNotEmpty);
 
   final Category? selectedCategory;
   final List<CategoryType> categoryType;
+
+  /// IDs of categories to exclude from the list
+  final List<String> excludeCategoriesWithId;
 
   final bool showSubcategories;
 
@@ -91,6 +95,7 @@ class _CategoryPickerState extends State<CategoryPicker>
               predicate: (c, p) => AppDB.instance.buildExpr([
                 c.parentCategoryID.isNull(),
                 c.type.isInValues(widget.categoryType),
+                c.id.isNotIn(widget.excludeCategoriesWithId),
                 drift.Expression.or([
                   c.name.contains(searchContoller.text),
                   if (selectedCategory != null)


### PR DESCRIPTION
## Description

With this change, when you select “create subcategory” or “merge category,” you cannot select the same categorywhere you are currently located.

## ✅ Checklist

Before submitting your PR, please ensure the following:

<!--- 💡Tip: Tick checkboxes like this: [x] --->

- [X] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [X] I confirm that I've run the code locally and everything works as expected.

## 🔗 Related Issues

- Fixes #372  
