### PR TITLE
New visibility for pending future transactions and new date separators UI

### DIFF
--- a/lib/app/accounts/details/account_details.dart
+++ b/lib/app/accounts/details/account_details.dart
@@ -10,6 +10,7 @@ import 'package:monekin/app/layout/page_framework.dart';
 import 'package:monekin/app/transactions/label_value_info_list.dart';
 import 'package:monekin/app/transactions/transactions.page.dart';
 import 'package:monekin/app/transactions/widgets/transaction_list.dart';
+import 'package:monekin/app/transactions/widgets/transaction_list_tile.dart';
 import 'package:monekin/core/database/services/account/account_service.dart';
 import 'package:monekin/core/database/services/exchange-rate/exchange_rate_service.dart';
 import 'package:monekin/core/database/services/transaction/transaction_service.dart';
@@ -193,8 +194,11 @@ class _AccountDetailsPageState extends State<AccountDetailsPage> {
                           },
                         ),
                         body: TransactionListComponent(
-                          heroTagBuilder: (tr) =>
-                              'account-details-page__tr-icon-${tr.id}',
+                          tileBuilder: (transaction) => TransactionListTile(
+                            transaction: transaction,
+                            heroTag:
+                                'account-details-page__tr-icon-${transaction.id}',
+                          ),
                           filters: TransactionFilters(
                             status: TransactionStatus.notIn({
                               TransactionStatus.pending,

--- a/lib/app/budgets/budget_details_page.dart
+++ b/lib/app/budgets/budget_details_page.dart
@@ -8,6 +8,7 @@ import 'package:monekin/app/budgets/components/budget_evolution_chart.dart';
 import 'package:monekin/app/layout/page_framework.dart';
 import 'package:monekin/app/stats/widgets/movements_distribution/pie_chart_by_categories.dart';
 import 'package:monekin/app/transactions/widgets/transaction_list.dart';
+import 'package:monekin/app/transactions/widgets/transaction_list_tile.dart';
 import 'package:monekin/core/database/services/budget/budget_service.dart';
 import 'package:monekin/core/database/services/currency/currency_service.dart';
 import 'package:monekin/core/extensions/color.extensions.dart';
@@ -206,8 +207,11 @@ class _BudgetDetailsPageState extends State<BudgetDetailsPage>
                     ),
                     SingleChildScrollView(
                       child: TransactionListComponent(
-                        heroTagBuilder: (tr) =>
-                            'budgets-page__tr-icon-${tr.id}',
+                        isScrollable: true,
+                        tileBuilder: (transaction) => TransactionListTile(
+                          transaction: transaction,
+                          heroTag: 'budgets-page__tr-icon-${transaction.id}',
+                        ),
                         filters: budget.trFilters,
                         onEmptyList: NoResults(
                           title: t.general.empty_warn,

--- a/lib/app/transactions/recurrent_transactions_page.dart
+++ b/lib/app/transactions/recurrent_transactions_page.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:monekin/app/layout/page_framework.dart';
 import 'package:monekin/app/transactions/widgets/transaction_list.dart';
+import 'package:monekin/app/transactions/widgets/transaction_list_tile.dart';
 import 'package:monekin/core/database/services/transaction/transaction_service.dart';
 import 'package:monekin/core/extensions/padding.extension.dart';
 import 'package:monekin/core/models/date-utils/periodicity.dart';
@@ -53,10 +54,15 @@ class _RecurrentTransactionPageState extends State<RecurrentTransactionPage> {
           Expanded(
             child: TransactionListComponent(
               filters: const TransactionFilters(isRecurrent: true),
-              periodicityInfo: periodicity,
               showGroupDivider: false,
-              heroTagBuilder: (tr) =>
-                  'recurrent-transactions-page__tr-icon-${tr.id}',
+              isScrollable: true,
+              tileBuilder: (transaction) => TransactionListTile(
+                transaction: transaction,
+                heroTag:
+                    'recurrent-transactions-page__tr-icon-${transaction.id}',
+                periodicityInfo: periodicity,
+                showTime: false,
+              ),
               onEmptyList: Center(
                 child: NoResults(
                   title: t.general.empty_warn,

--- a/lib/app/transactions/transactions.page.dart
+++ b/lib/app/transactions/transactions.page.dart
@@ -8,7 +8,9 @@ import 'package:monekin/app/layout/page_context.dart';
 import 'package:monekin/app/layout/page_framework.dart';
 import 'package:monekin/app/transactions/widgets/bulk_edit_transaction_modal.dart';
 import 'package:monekin/app/transactions/widgets/transaction_list.dart';
+import 'package:monekin/app/transactions/widgets/transaction_list_tile.dart';
 import 'package:monekin/core/database/services/transaction/transaction_service.dart';
+import 'package:monekin/core/extensions/padding.extension.dart';
 import 'package:monekin/core/models/transaction/transaction.dart';
 import 'package:monekin/core/presentation/helpers/snackbar.dart';
 import 'package:monekin/core/presentation/widgets/confirm_dialog.dart';
@@ -42,6 +44,12 @@ class TransactionsPageState extends State<TransactionsPage> {
   final ScrollController listScrollController = ScrollController();
 
   List<MoneyTransaction> selectedTransactions = [];
+
+  void resetScroll() {
+    if (listScrollController.hasClients) {
+      listScrollController.jumpTo(0);
+    }
+  }
 
   @override
   void initState() {
@@ -214,17 +222,26 @@ class TransactionsPageState extends State<TransactionsPage> {
             Expanded(
               child: TransactionListComponent(
                 scrollController: listScrollController,
-                heroTagBuilder: (tr) => 'transactions-page__tr-icon-${tr.id}',
+                isScrollable: true,
+                listPadding: const EdgeInsets.only(
+                  bottom: 64,
+                ).withSafeBottom(context),
+                tileBuilder: (tr) => TransactionListTile(
+                  transaction: tr,
+                  heroTag: 'transactions-page__tr-icon-${tr.id}',
+                  onLongPress: selectedTransactions.isNotEmpty
+                      ? null
+                      : () => toggleTransaction(tr),
+                  onTap: selectedTransactions.isEmpty
+                      ? null
+                      : () => toggleTransaction(tr),
+                  isSelected: selectedTransactions.any(
+                    (element) => element.id == tr.id,
+                  ),
+                  showDate: false,
+                  applySwipeActions: true,
+                ),
                 filters: filters.copyWith(searchValue: searchController.text),
-                selectedTransactions: selectedTransactions,
-                onLongPress: (tr) {
-                  if (selectedTransactions.isNotEmpty) {
-                    return;
-                  }
-
-                  toggleTransaction(tr);
-                },
-                onTap: selectedTransactions.isEmpty ? null : toggleTransaction,
                 onEmptyList: NoResults(
                   title: filters.hasFilter ? null : t.general.empty_warn,
                   description: filters.hasFilter

--- a/lib/app/transactions/widgets/transaction_list_date_separator.dart
+++ b/lib/app/transactions/widgets/transaction_list_date_separator.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:monekin/core/database/services/transaction/transaction_service.dart';
+import 'package:monekin/core/presentation/widgets/number_ui_formatters/currency_displayer.dart';
+import 'package:monekin/core/presentation/widgets/transaction_filter/transaction_filters.dart';
+import 'package:monekin/i18n/generated/translations.g.dart';
+
+class TransactionListDateSeparator extends StatelessWidget {
+  const TransactionListDateSeparator({
+    super.key,
+    required this.filters,
+    required this.date,
+  });
+
+  final TransactionFilters filters;
+  final DateTime date;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Translations.of(context);
+
+    final isFutureDate = date.isAfter(DateTime.now());
+
+    return Opacity(
+      opacity: isFutureDate ? 0.5 : 1.0,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        margin: const EdgeInsets.only(top: 8),
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: Theme.of(context).dividerColor,
+              width: 0.5,
+            ),
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          spacing: 12,
+          children: [
+            DefaultTextStyle(
+              style: Theme.of(context).textTheme.labelMedium!,
+              child: Row(
+                spacing: 8,
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    DateFormat.d().format(date),
+                    style: TextStyle(fontSize: 26),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Text(
+                        (DateUtils.isSameDay(date, DateTime.now())
+                                ? t.general.today
+                                : DateFormat.EEEE().format(date))
+                            .toUpperCase(),
+                        style: Theme.of(context).textTheme.labelSmall!.copyWith(
+                          fontWeight: FontWeight.w300,
+                        ),
+                      ),
+                      Text(DateFormat.yMMMM().format(date)),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            if (!isFutureDate)
+              StreamBuilder(
+                initialData: 0.0,
+                stream: TransactionService.instance.getTransactionsValueBalance(
+                  filters: filters.copyWith(
+                    minDate: DateTime(date.year, date.month, date.day),
+                    maxDate: DateTime(date.year, date.month, date.day + 1),
+                  ),
+                ),
+                builder: (context, snapshot) {
+                  final partialBalance = snapshot.data!;
+
+                  return CurrencyDisplayer(
+                    amountToConvert: partialBalance,
+                    integerStyle: Theme.of(context).textTheme.labelLarge!,
+                  );
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

New visibility for pending transactions and new date separators UI. Now the future transactions will be displayed in kind of a separate list, user has to scroll up to see it. Users will have also the count of pending transactions that they have

## ✅ Checklist

Before submitting your PR, please ensure the following:

<!--- 💡Tip: Tick checkboxes like this: [x] --->

- [X] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [X] I confirm that I've run the code locally and everything works as expected.

## 📸 Screenshots or Demo (if applicable)

https://github.com/user-attachments/assets/05d350ab-7413-4bdb-b6fb-379163d75c7a

## 🔗 Related Issues

- Closes #410  
- Closes #254

