### PR TITLE
Migrate transaction status to save DB space

### DIFF
--- a/assets/sql/migrations/v9.sql
+++ b/assets/sql/migrations/v9.sql
@@ -30,3 +30,17 @@ VALUES ('ETH', 'Ξ', 'Ethereum', 6, 1, 0);
 
 --- ----------- NEW USER SETTINGS ------------
 INSERT INTO userSettings VALUES ('defaultTransactionType', 'E');
+
+--- ----------- TRANSACTION STATUS MIGRATION ------------
+-- 1. Add new temporary column with the new check constraint
+ALTER TABLE transactions ADD COLUMN status_new TEXT CHECK(status_new IN ('V', 'P', 'R', 'U'));
+
+-- 2. Migrate data from old column to new column
+UPDATE transactions SET status_new = 'V' WHERE status = 'voided';
+UPDATE transactions SET status_new = 'P' WHERE status = 'pending';
+UPDATE transactions SET status_new = 'R' WHERE status = 'reconciled';
+UPDATE transactions SET status_new = 'U' WHERE status = 'unreconciled';
+
+-- 3. Drop the old column and rename the new column to the original name
+ALTER TABLE transactions DROP COLUMN status;
+ALTER TABLE transactions RENAME COLUMN status_new TO status;

--- a/lib/core/database/sql/initial/tables.drift
+++ b/lib/core/database/sql/initial/tables.drift
@@ -122,7 +122,7 @@ CREATE TABLE IF NOT EXISTS transactions (
   -- Whether the transacton is an income, an expense or a transfer
   type TEXT NOT NULL CHECK(type IN ('E', 'I', 'T')) MAPPED BY `CustomEnumConverter(TransactionType.values)`,
   
-  status ENUMNAME(TransactionStatus) CHECK(status IN ('voided', 'pending', 'reconciled', 'unreconciled')),
+  status TEXT CHECK(status IN ('V', 'P', 'R', 'U')) MAPPED BY `CustomEnumConverter(TransactionStatus.values)`,
   categoryID TEXT REFERENCES categories(id) ON DELETE CASCADE ON UPDATE CASCADE,
   valueInDestiny REAL,
   receivingAccountID TEXT REFERENCES accounts(id) ON DELETE CASCADE ON UPDATE CASCADE,

--- a/lib/core/database/sql/queries/select-full-data.drift
+++ b/lib/core/database/sql/queries/select-full-data.drift
@@ -109,7 +109,7 @@ countTransactions($predicate = TRUE, :date AS DATETIME):
                                 SELECT MAX(date) 
                                 FROM exchangeRates
                                 WHERE currencyCode = er.currencyCode 
-                                AND DATE <= :date
+                                AND unixepoch(DATE) <= unixepoch(:date)
                             )
                 ORDER BY currencyCode
         )
@@ -123,7 +123,7 @@ countTransactions($predicate = TRUE, :date AS DATETIME):
                                 SELECT MAX(date) 
                                 FROM exchangeRates
                                 WHERE currencyCode = er.currencyCode 
-                                AND DATE <= :date
+                                AND unixepoch(DATE) <= unixepoch(:date)
                             )
                 ORDER BY currencyCode
         )

--- a/lib/core/models/transaction/transaction_status.enum.dart
+++ b/lib/core/models/transaction/transaction_status.enum.dart
@@ -1,16 +1,24 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:monekin/core/database/utils/database_enum.dart';
 import 'package:monekin/i18n/generated/translations.g.dart';
 
 /// Literally the `null` value, just casted to TransactionStatus? to avoid
 /// issues with null safety
 const nullTransactionStatus = null as TransactionStatus?;
 
-enum TransactionStatus {
-  voided,
-  pending,
-  reconciled,
-  unreconciled;
+enum TransactionStatus implements DatabaseEnum<String> {
+  voided('V'),
+  pending('P'),
+  reconciled('R'),
+  unreconciled('U');
+
+  const TransactionStatus(this.id);
+
+  final String id;
+
+  @override
+  String get databaseValue => id;
 
   /// Get a list of statuses that are not in a set of statuses.
   ///


### PR DESCRIPTION
## Description

Migrate transaction status to save DB space. 

Before we were using the full transaction status name to store the value in the database, now only the ID of the status is stored.

## ✅ Checklist

Before submitting your PR, please ensure the following:

<!--- 💡Tip: Tick checkboxes like this: [x] --->

- [X] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [X] I confirm that I've run the code locally and everything works as expected.

## 📝 Additional Notes

Space saved estimation in the app device:

| # of transactions        | Space saved |
|-------------|-------------|
| 300         | ~3 KB       |
| 1,000       | ~10 KB      |
| 10,000      | ~100 KB     |
| 100,000     | ~1 MB       |
| 1,000,000   | ~10 MB      |
| 10,000,000  | ~100 MB     |

