### PR TITLE
Removed trailing comma

### DIFF
--- a/lib/i18n/json/zh-TW.json
+++ b/lib/i18n/json/zh-TW.json
@@ -997,7 +997,7 @@
         "success": "已成功導入{{x}}筆交易"
       },
       "success": "導入成功",
-      "error": "匯入檔案時發生錯誤。請透過 lozin.technologies@gmail.com 聯絡開發人員。",
+      "error": "匯入檔案時發生錯誤。請透過 lozin.technologies@gmail.com 聯絡開發人員。"
     },
     "ABOUT": {
       "title": "有關您的資料庫的資訊",


### PR DESCRIPTION
A trailing comma in the zh-TW.json file was causing errors in the develop branch. I fixed it.
Request @enrique-lozano to merge this immediately.
