### PR TITLE
 Persist dashboard selected date range

### DIFF
--- a/lib/app/home/dashboard.page.dart
+++ b/lib/app/home/dashboard.page.dart
@@ -29,7 +29,7 @@ import 'package:monekin/core/utils/app_utils.dart';
 import 'package:monekin/i18n/generated/translations.g.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:skeletonizer/skeletonizer.dart';
-
+import '../../core/models/date-utils/date_period.dart';
 import '../../core/models/transaction/transaction_type.enum.dart';
 import '../../core/presentation/app_colors.dart';
 
@@ -56,6 +56,7 @@ class _DashboardPageState extends State<DashboardPage> {
     });
 
     _balanceVariationStream = _getBalanceVariationStream();
+    _loadSavedDatePeriod();
   }
 
   @override
@@ -63,6 +64,22 @@ class _DashboardPageState extends State<DashboardPage> {
     _scrollController.removeListener(_setSmallHeaderVisible);
     _scrollController.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadSavedDatePeriod() async {
+    final savedPeriodJson = appStateSettings[SettingKey.dashboardDatePeriod];
+
+    if (savedPeriodJson != null) {
+      try {
+        final period = DatePeriod.fromJsonString(savedPeriodJson);
+        setState(() {
+          dateRangeService = dateRangeService.copyWith(datePeriod: period);
+          _balanceVariationStream = _getBalanceVariationStream();
+        });
+      } catch (_) {
+        // Fall back to default
+      }
+    }
   }
 
   Stream<double> _getBalanceVariationStream() {
@@ -273,6 +290,11 @@ class _DashboardPageState extends State<DashboardPage> {
           DatePeriodModal(initialDatePeriod: dateRangeService.datePeriod),
         ).then((value) {
           if (value == null) return;
+
+          UserSettingService.instance.setItem(
+            SettingKey.dashboardDatePeriod,
+            value.toJsonString(),
+          );
 
           setState(() {
             dateRangeService = dateRangeService.copyWith(

--- a/lib/app/home/dashboard.page.dart
+++ b/lib/app/home/dashboard.page.dart
@@ -29,6 +29,7 @@ import 'package:monekin/core/utils/app_utils.dart';
 import 'package:monekin/i18n/generated/translations.g.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:skeletonizer/skeletonizer.dart';
+import '../../core/database/services/app-data/app_data_service.dart';
 import '../../core/models/date-utils/date_period.dart';
 import '../../core/models/transaction/transaction_type.enum.dart';
 import '../../core/presentation/app_colors.dart';
@@ -67,7 +68,7 @@ class _DashboardPageState extends State<DashboardPage> {
   }
 
   Future<void> _loadSavedDatePeriod() async {
-    final savedPeriodJson = appStateSettings[SettingKey.dashboardDatePeriod];
+    final savedPeriodJson = appStateData[AppDataKey.lastDashboardDatePeriod];
 
     if (savedPeriodJson != null) {
       try {
@@ -291,8 +292,8 @@ class _DashboardPageState extends State<DashboardPage> {
         ).then((value) {
           if (value == null) return;
 
-          UserSettingService.instance.setItem(
-            SettingKey.dashboardDatePeriod,
+          AppDataService.instance.setItem(
+            AppDataKey.lastDashboardDatePeriod,
             value.toJsonString(),
           );
 

--- a/lib/core/database/services/app-data/app_data_service.dart
+++ b/lib/core/database/services/app-data/app_data_service.dart
@@ -3,7 +3,7 @@ import 'package:monekin/core/database/services/shared/key_value_pair.dart';
 import 'package:monekin/core/database/services/shared/key_value_service.dart';
 
 /// The keys of the avalaible settings of the app
-enum AppDataKey { dbVersion, introSeen, lastExportDate }
+enum AppDataKey { dbVersion, introSeen, lastExportDate, lastDashboardDatePeriod }
 
 final Map<AppDataKey, String?> appStateData = {};
 

--- a/lib/core/database/services/user-setting/user_setting_service.dart
+++ b/lib/core/database/services/user-setting/user_setting_service.dart
@@ -51,6 +51,9 @@ enum SettingKey {
 
   /// Whether to show the time of the transaction in the transaction list tiles
   transactionTileShowTime,
+
+  /// JSON string representing the last selected date period on the dashboard
+  dashboardDatePeriod,
 }
 
 final Map<SettingKey, String?> appStateSettings = {};

--- a/lib/core/database/services/user-setting/user_setting_service.dart
+++ b/lib/core/database/services/user-setting/user_setting_service.dart
@@ -51,9 +51,6 @@ enum SettingKey {
 
   /// Whether to show the time of the transaction in the transaction list tiles
   transactionTileShowTime,
-
-  /// JSON string representing the last selected date period on the dashboard
-  dashboardDatePeriod,
 }
 
 final Map<SettingKey, String?> appStateSettings = {};

--- a/lib/core/models/date-utils/date_period.dart
+++ b/lib/core/models/date-utils/date_period.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:monekin/core/models/date-utils/period_type.dart';
 import 'package:monekin/core/models/date-utils/periodicity.dart';
@@ -30,6 +31,33 @@ class DatePeriod {
 
   const DatePeriod.customRange(DateTime? start, DateTime? end)
     : this(periodType: PeriodType.dateRange, customDateRange: (start, end));
+
+  Map<String, dynamic> toJson() => {
+    'periodType': periodType.name,
+    'periodicity': periodicity.name,
+    'lastDays': lastDays,
+    'customDateRangeStart': customDateRange.$1?.millisecondsSinceEpoch,
+    'customDateRangeEnd': customDateRange.$2?.millisecondsSinceEpoch,
+  };
+
+  factory DatePeriod.fromJson(Map<String, dynamic> json) => DatePeriod(
+    periodType: PeriodType.values.byName(json['periodType'] as String),
+    periodicity: Periodicity.values.byName(json['periodicity'] as String),
+    lastDays: json['lastDays'] as int,
+    customDateRange: (
+    json['customDateRangeStart'] != null
+      ? DateTime.fromMillisecondsSinceEpoch(json['customDateRangeStart'] as int)
+      : null,
+    json['customDateRangeEnd'] != null
+      ? DateTime.fromMillisecondsSinceEpoch(json['customDateRangeEnd'] as int)
+      : null,
+    ),
+  );
+
+  String toJsonString() => jsonEncode(toJson());
+
+  factory DatePeriod.fromJsonString(String raw) =>
+    DatePeriod.fromJson(jsonDecode(raw) as Map<String, dynamic>);
 
   @override
   String toString() {


### PR DESCRIPTION
<!--- 

🎉 Thanks for contributing to the app! We appreciate your effort and time. 

Please take your time to fill this template. 

--->

## Description

Please provide here a brief summary of the purpose of this Pull Request. Clearly explain what changes are introduced and what problem they solve. Keep it concise and to the point.

Added persist-selected-cycle functionality. Now when the user enters the app they will see the same cycle that they had selected before leaving the app.

## ✅ Checklist

Before submitting your PR, please ensure the following:

<!--- 💡Tip: Tick checkboxes like this: [x] --->

- [x] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [x] I confirm that I've run the code locally and everything works as expected.

## 📸 Screenshots or Demo (if applicable)

_If your changes include UI updates, please attach screenshots or a screen recording of the changes._

BEFORE:

https://github.com/user-attachments/assets/ca0de5eb-78e7-45fe-b030-e6175d1cf875


AFTER:

https://github.com/user-attachments/assets/709fa6cd-5d55-4c88-b25c-02d2d1f103d6

## 🔗 Related Issues

_List any issues this PR addresses. Use keywords like `Fixes` or `Closes` to link issues._

- Fixes #365 
- Closes #365 

_You can remove this section if there are no linked issues_

## 📝 Additional Notes

_Add any additional information or context that might be helpful for reviewers. Usually, code related stuff. You can divide this section as you consider._

Previously, the dashboard would always reset to the default monthly cycle whenever the app was launched, regardless of what the user had selected before. This happened because dateRangeService was initialized fresh as const DatePeriodState() on every app start, with no mechanism to remember the user's last selection.

To fix this, we added JSON serialization to DatePeriod so it could be converted to a string and stored in the app's existing key-value database. A new SettingKey.dashboardDatePeriod key was added to hold this value. On the dashboard, whenever the user selects a new cycle, it gets persisted to the database immediately. On app launch, the saved value is read from memory and restored before the dashboard renders.

The end result is that whatever cycle the user had selected before closing the app will be exactly what they see when they come back. This applies to all cycle types including custom date ranges, last N days, specific periodicities, and all time.