### PR TITLE
Do not show category picker when a default category is set

### DIFF
--- a/lib/app/settings/pages/default_form_transacation_values.page.dart
+++ b/lib/app/settings/pages/default_form_transacation_values.page.dart
@@ -153,7 +153,7 @@ class DefaultFormTransactionValuesPage extends StatelessWidget {
 
         return ListTile(
           title: Text(t.settings.transactions.default_values.default_category),
-          subtitle: Text(category.name),
+          subtitle: Text(snapshot.data?.name ?? t.general.unspecified),
           leading: IconDisplayer.fromCategory(
             context,
             category: category,

--- a/lib/app/transactions/form/state/transaction_form_controller.dart
+++ b/lib/app/transactions/form/state/transaction_form_controller.dart
@@ -221,8 +221,13 @@ class TransactionFormController extends ChangeNotifier {
       _requestAmountFocusSoon();
       return;
     }
-    await selectCategory(context);
-    if (_disposed || !context.mounted) return;
+    // Only prompt for a category when none was prefilled by the form defaults
+    // (a default/last-used category being set means the user doesn't expect the
+    // picker sheet to open automatically).
+    if (selectedCategory == null) {
+      await selectCategory(context);
+      if (_disposed || !context.mounted) return;
+    }
     _requestAmountFocusSoon();
   }
 


### PR DESCRIPTION
## Description

Fixes a bug in the transaction form where the category selection sheet was shown automatically on create even when a default category was already set.

When creating a new income/expense transaction, the form prefills the category from the user's form defaults (either the "use last-used value" field toggle or an explicit default category). However, the create bootstrap opened the category picker sheet unconditionally, so it popped up even though a category was already selected. Now the picker is only opened automatically when no category was prefilled.

## ✅ Checklist

Before submitting your PR, please ensure the following:

<!--- 💡Tip: Tick checkboxes like this: [x] --->

- [X] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [X] I confirm that I've run the code locally and everything works as expected.
