### PR TITLE
Unable to delete transaction from accounts page

### DIFF
--- a/lib/core/presentation/widgets/confirm_dialog.dart
+++ b/lib/core/presentation/widgets/confirm_dialog.dart
@@ -39,7 +39,7 @@ Future<bool?> confirmDialog(
     },
     transitionDuration: Duration(milliseconds: 200),
     useRootNavigator: useRootNavigator,
-    pageBuilder: (_, _, _) => PopScope(
+    pageBuilder: (dialogContext, _, _) => PopScope(
       canPop: canPop,
       child: AlertDialog.adaptive(
         title: Text(dialogTitle),
@@ -58,17 +58,18 @@ Future<bool?> confirmDialog(
               child: Text(t.ui_actions.cancel),
               onPressed: () {
                 Navigator.of(
-                  context,
+                  dialogContext,
                   rootNavigator: useRootNavigator,
                 ).pop(false);
-
-                // NOW EVERY TIME I PRESS THE PHYSICAL DEVICE BACK BUTTON, IT CLOSES THE APP
               },
             ),
           TextButton(
             child: Text(confirmationText ?? t.general.understood),
             onPressed: () {
-              Navigator.of(context, rootNavigator: useRootNavigator).pop(true);
+              Navigator.of(
+                dialogContext,
+                rootNavigator: useRootNavigator,
+              ).pop(true);
             },
           ),
         ],


### PR DESCRIPTION
## Description

Fix an issue that prevented deleting a transaction from the account details page. When deleting through the transaction tile's long-press menu, the confirmation dialog's `Continue` button had no effect because the dialog was being closed using the already-dismissed bottom sheet's context. The dialog now uses its own context to close, so the deletion is confirmed correctly.

Closes #491

## ✅ Checklist

Before submitting your PR, please ensure the following:

<!--- 💡Tip: Tick checkboxes like this: [x] --->

- [X] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [X] I confirm that I've run the code locally and everything works as expected.
