### PR TITLE
Set desktop window min size and fix tiny render on launch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -56,6 +57,23 @@ void main() async {
 
   debugPaintSizeEnabled = false;
   runApp(InitializeApp(key: appStateKey));
+
+  _setupDesktopWindow();
+}
+
+/// Configures the desktop window (min size + initial size) once bitsdojo's
+/// custom-frame window is ready.
+void _setupDesktopWindow() {
+  if (kIsWeb || !AppUtils.isDesktop) return;
+
+  doWhenWindowReady(() {
+    const initialSize = Size(1280, 720);
+
+    appWindow.minSize = const Size(420, 500);
+    appWindow.size = initialSize;
+    appWindow.alignment = Alignment.center;
+    appWindow.show();
+  });
 }
 
 // ignore: library_private_types_in_public_api


### PR DESCRIPTION
## Summary

Sets a minimum size for the desktop window and fixes the bug where the app rendered at a tiny scale on launch until the window was manually resized.

## Details

The app uses `bitsdojo_window` with a custom frame but never called `doWhenWindowReady`, so no minimum size was enforced and the view size was never applied on startup. Now, on desktop, `main()` configures the window once it is ready:

- `appWindow.minSize = Size(600, 600)` — prevents shrinking the window below a usable size.
- `appWindow.size` + `appWindow.show()` inside `doWhenWindowReady` — applies the view size on launch, fixing the "tiny render until resize" issue.

Guarded to desktop only (`kIsWeb || !AppUtils.isDesktop` short-circuits).

## Test plan

- [x] `flutter run -d windows` opens the window centered at full size (no tiny render).
- [x] The window cannot be resized below 420x500.
- [x] Android/web builds are unaffected.
