### PR TITLE
Update profile in UI reactively after saving

### DIFF
--- a/lib/app/home/dashboard.page.dart
+++ b/lib/app/home/dashboard.page.dart
@@ -14,7 +14,6 @@ import 'package:monekin/app/stats/stats_page.dart';
 import 'package:monekin/app/stats/widgets/movements_distribution/pie_chart_by_categories.dart';
 import 'package:monekin/core/database/services/account/account_service.dart';
 import 'package:monekin/core/database/services/user-setting/private_mode_service.dart';
-import 'package:monekin/core/database/services/user-setting/user_setting_service.dart';
 import 'package:monekin/core/models/date-utils/date_period.dart';
 import 'package:monekin/core/models/date-utils/date_period_state.dart';
 import 'package:monekin/core/models/transaction/transaction_type.enum.dart';
@@ -31,6 +30,7 @@ import 'package:monekin/core/presentation/widgets/income_expense_flow_card.dart'
 import 'package:monekin/core/presentation/widgets/number_ui_formatters/currency_displayer.dart';
 import 'package:monekin/core/presentation/widgets/tappable.dart';
 import 'package:monekin/core/presentation/widgets/user_avatar.dart';
+import 'package:monekin/core/presentation/widgets/user_profile_builder.dart';
 import 'package:monekin/core/routes/route_utils.dart';
 import 'package:monekin/i18n/generated/translations.g.dart';
 import 'package:rxdart/rxdart.dart';
@@ -465,37 +465,39 @@ class _DashboardPageState extends State<DashboardPage> {
       },
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            UserAvatar(avatar: appStateSettings[SettingKey.avatar]),
-            const SizedBox(width: 12),
-            Flexible(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    _welcomeGreeting,
-                    softWrap: false,
-                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                      color: AppColors.of(context).textHint,
-                      overflow: TextOverflow.fade,
+        child: UserProfileBuilder(
+          builder: (context, userName, avatar) => Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              UserAvatar(avatar: avatar),
+              const SizedBox(width: 12),
+              Flexible(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      _welcomeGreeting,
+                      softWrap: false,
+                      style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                        color: AppColors.of(context).textHint,
+                        overflow: TextOverflow.fade,
+                      ),
                     ),
-                  ),
-                  Text(
-                    appStateSettings[SettingKey.userName] ?? 'User',
-                    softWrap: false,
-                    style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                      fontSize: 18,
-                      fontWeight: FontWeight.w700,
-                      overflow: TextOverflow.fade,
+                    Text(
+                      userName ?? 'User',
+                      softWrap: false,
+                      style: Theme.of(context).textTheme.titleMedium!.copyWith(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w700,
+                        overflow: TextOverflow.fade,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/app/layout/widgets/app_navigation_drawer.dart
+++ b/lib/app/layout/widgets/app_navigation_drawer.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:monekin/app/home/widgets/new_transaction_fl_button.dart';
 import 'package:monekin/app/layout/window_bar.dart';
-import 'package:monekin/core/database/services/user-setting/user_setting_service.dart';
 import 'package:monekin/core/extensions/color.extensions.dart';
 import 'package:monekin/core/presentation/app_colors.dart';
 import 'package:monekin/core/presentation/widgets/user_avatar.dart';
+import 'package:monekin/core/presentation/widgets/user_profile_builder.dart';
 import 'package:monekin/core/routes/destinations.dart';
 import 'package:monekin/core/utils/app_utils.dart';
 
@@ -39,35 +39,37 @@ class SideNavigationDrawer extends StatelessWidget {
         ),
         footer: Container(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            spacing: 12,
-            children: [
-              UserAvatar(
-                avatar: appStateSettings[SettingKey.avatar],
-                backgroundColor: AppColors.of(
-                  context,
-                ).onConsistentPrimary.darken(0.25),
-                border: Border.all(
-                  width: 2,
-                  color: AppColors.of(context).onConsistentPrimary,
-                ),
-              ),
-              Expanded(
-                child: ListTile(
-                  contentPadding: const EdgeInsets.all(0),
-                  title: Text(
-                    appStateSettings[SettingKey.userName] ?? 'User',
-                    softWrap: false,
-                    style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                      fontSize: 18,
-                      overflow: TextOverflow.fade,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
+          child: UserProfileBuilder(
+            builder: (context, userName, avatar) => Row(
+              spacing: 12,
+              children: [
+                UserAvatar(
+                  avatar: avatar,
+                  backgroundColor: AppColors.of(
+                    context,
+                  ).onConsistentPrimary.darken(0.25),
+                  border: Border.all(
+                    width: 2,
+                    color: AppColors.of(context).onConsistentPrimary,
                   ),
-                  subtitle: Text('Thanks for trust us ❤️'),
                 ),
-              ),
-            ],
+                Expanded(
+                  child: ListTile(
+                    contentPadding: const EdgeInsets.all(0),
+                    title: Text(
+                      userName ?? 'User',
+                      softWrap: false,
+                      style: Theme.of(context).textTheme.titleSmall!.copyWith(
+                        fontSize: 18,
+                        overflow: TextOverflow.fade,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                    subtitle: Text('Thanks for trust us ❤️'),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
         children: List.generate(drawerActions.length, (index) {

--- a/lib/app/layout/widgets/app_navigation_sidebar.dart
+++ b/lib/app/layout/widgets/app_navigation_sidebar.dart
@@ -4,12 +4,12 @@ import 'package:flutter/material.dart';
 import 'package:monekin/app/home/widgets/new_transaction_fl_button.dart';
 import 'package:monekin/app/layout/widgets/app_navigation_drawer.dart';
 import 'package:monekin/app/layout/window_bar.dart';
-import 'package:monekin/core/database/services/user-setting/user_setting_service.dart';
 import 'package:monekin/core/extensions/color.extensions.dart';
 import 'package:monekin/core/presentation/app_colors.dart';
 import 'package:monekin/core/presentation/responsive/breakpoint_container.dart';
 import 'package:monekin/core/presentation/responsive/breakpoints.dart';
 import 'package:monekin/core/presentation/widgets/user_avatar.dart';
+import 'package:monekin/core/presentation/widgets/user_profile_builder.dart';
 import 'package:monekin/core/routes/content_modal_observer.dart';
 import 'package:monekin/core/routes/destinations.dart';
 import 'package:monekin/core/routes/route_utils.dart';
@@ -102,14 +102,16 @@ class AppNavigationSidebarState extends State<AppNavigationSidebar> {
               trailing: Container(
                 margin: const EdgeInsets.symmetric(vertical: 16),
                 alignment: Alignment.bottomCenter,
-                child: UserAvatar(
-                  avatar: appStateSettings[SettingKey.avatar],
-                  backgroundColor: AppColors.of(
-                    context,
-                  ).onConsistentPrimary.darken(0.25),
-                  border: Border.all(
-                    width: 2,
-                    color: AppColors.of(context).onConsistentPrimary,
+                child: UserProfileBuilder(
+                  builder: (context, userName, avatar) => UserAvatar(
+                    avatar: avatar,
+                    backgroundColor: AppColors.of(
+                      context,
+                    ).onConsistentPrimary.darken(0.25),
+                    border: Border.all(
+                      width: 2,
+                      color: AppColors.of(context).onConsistentPrimary,
+                    ),
                   ),
                 ),
               ),

--- a/lib/core/database/services/user-setting/user_setting_service.dart
+++ b/lib/core/database/services/user-setting/user_setting_service.dart
@@ -1,6 +1,7 @@
 import 'package:monekin/core/database/app_db.dart';
 import 'package:monekin/core/database/services/shared/key_value_pair.dart';
 import 'package:monekin/core/database/services/shared/key_value_service.dart';
+import 'package:rxdart/rxdart.dart';
 
 /// The keys of the avalaible settings of the app
 enum SettingKey {
@@ -76,5 +77,16 @@ class UserSettingService
           ..where((tbl) => tbl.settingKey.equalsValue(settingKey)))
         .map((e) => e.settingValue)
         .watchSingleOrNull();
+  }
+
+  /// Reactive stream of the user profile (name + avatar). Emits a new value
+  /// whenever either setting changes in the DB, so widgets displaying the
+  /// profile can rebuild on their own without refreshing the whole app state.
+  Stream<({String? userName, String? avatar})> getUserProfile() {
+    return Rx.combineLatest2(
+      getSettingFromDB(SettingKey.userName),
+      getSettingFromDB(SettingKey.avatar),
+      (userName, avatar) => (userName: userName, avatar: avatar),
+    );
   }
 }

--- a/lib/core/presentation/widgets/user_profile_builder.dart
+++ b/lib/core/presentation/widgets/user_profile_builder.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:monekin/core/database/services/user-setting/user_setting_service.dart';
+
+/// Reactively builds a widget with the current user profile (name + avatar).
+///
+/// It watches the profile settings from the DB, so it rebuilds only itself
+/// whenever the profile changes (e.g. after editing it), instead of forcing a
+/// full app-state refresh. The initial data comes from [appStateSettings] to
+/// avoid any flicker on the first frame.
+class UserProfileBuilder extends StatelessWidget {
+  const UserProfileBuilder({super.key, required this.builder});
+
+  final Widget Function(BuildContext context, String? userName, String? avatar)
+  builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder(
+      stream: UserSettingService.instance.getUserProfile(),
+      initialData: (
+        userName: appStateSettings[SettingKey.userName],
+        avatar: appStateSettings[SettingKey.avatar],
+      ),
+      builder: (context, snapshot) {
+        return builder(context, snapshot.data!.userName, snapshot.data!.avatar);
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Description

Editing the profile (name/avatar) from the dashboard did not update the UI after pressing **Save** — the new values only appeared after a hot reload. This PR solves this issue.

### Causes

The dashboard header, the desktop navigation sidebar and drawer all read the user name and avatar directly from the in-memory, non-reactive `appStateSettings` map. `setItem(...)` updated that map and persisted to the DB, but nothing triggered a rebuild of those widgets.

### Changes

Instead of forcing a full app-state refresh (`updateGlobalState: true` → `refreshAppState()`, which rebuilds the whole widget tree), this uses a targeted, performant approach: a drift stream that only rebuilds the small profile widgets when the settings change.

- **`UserSettingService.getUserProfile()`** — new reactive stream that combines the `userName` and `avatar` settings (via `Rx.combineLatest2`), emitting on any change.
- **`UserProfileBuilder`** — small reusable widget wrapping a `StreamBuilder` over `getUserProfile()`, seeded with `initialData` from `appStateSettings` to avoid first-frame flicker.
- Dashboard header, navigation sidebar and drawer now render the avatar/name through `UserProfileBuilder`, so they update instantly after saving.

## ✅ Checklist

- [x] I've read and understand the Code Contributions Guide.
- [x] I confirm that I've run the code locally and everything works as expected.

## 📝 Additional Notes

- Only the profile widgets rebuild on change — no full app-state refresh, keeping this cheap.
- `flutter analyze` is clean and `dart format` applied on the touched files.
