### PR TITLE
Add missing account quick actions

### DIFF
--- a/lib/app/accounts/details/account_details.dart
+++ b/lib/app/accounts/details/account_details.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:monekin/app/accounts/account_form.dart';
+import 'package:monekin/app/accounts/balance_correction_modal.dart';
 import 'package:monekin/app/accounts/details/account_details_actions.dart';
 import 'package:monekin/app/accounts/details/account_snapshots.dart';
 import 'package:monekin/app/accounts/details/holdings_card.dart';
@@ -10,7 +11,6 @@ import 'package:monekin/app/accounts/details/holdings_snapshot_card.dart';
 import 'package:monekin/app/layout/page_framework.dart';
 import 'package:monekin/app/stats/widgets/fund_evolution_info.dart';
 import 'package:monekin/app/stats/widgets/movements_distribution/pie_chart_by_categories.dart';
-import 'package:monekin/app/transactions/form/transaction_form.page.dart';
 import 'package:monekin/app/transactions/list/transactions.page.dart';
 import 'package:monekin/app/transactions/list/widgets/transaction_list.dart';
 import 'package:monekin/app/transactions/list/widgets/transaction_list_tile.dart';
@@ -171,11 +171,11 @@ class _AccountDetailsPageState extends State<AccountDetailsPage> {
     bool isInvestment, {
     required bool wide,
   }) {
-    final menuActions = AccountDetailsActions.getAccountDetailsActions(
+    final menuActions = AccountDetailsActions.getAccountMenuActions(
       context,
       account: account,
       navigateBackOnDelete: true,
-    ).menu;
+    );
 
     return [
       if (wide) ...[
@@ -427,11 +427,9 @@ class _AccountDetailsPageState extends State<AccountDetailsPage> {
           color: Colors.green,
           onTap: disabled
               ? null
-              : () => RouteUtils.showResponsiveForm(
-                  TransactionFormPage(
-                    mode: TransactionType.income,
-                    fromAccount: account,
-                  ),
+              : () => AccountDetailsActions.navigateToTransferOrWarn(
+                  context,
+                  toAccount: account,
                 ),
         ),
         _QuickAction(
@@ -440,21 +438,20 @@ class _AccountDetailsPageState extends State<AccountDetailsPage> {
           color: Colors.red,
           onTap: disabled
               ? null
-              : () => RouteUtils.showResponsiveForm(
-                  TransactionFormPage(
-                    mode: TransactionType.expense,
-                    fromAccount: account,
-                  ),
-                ),
-        ),
-        _QuickAction(
-          icon: TransactionType.transfer.icon,
-          label: t.transfer.create,
-          onTap: disabled
-              ? null
               : () => AccountDetailsActions.navigateToTransferOrWarn(
                   context,
                   fromAccount: account,
+                ),
+        ),
+        _QuickAction(
+          icon: Icons.balance_rounded,
+          label: t.account.correct_balance,
+          onTap: disabled
+              ? null
+              : () => RouteUtils.showResponsiveSheet(
+                  context: context,
+                  builder: (context) =>
+                      BalanceCorrectionModal(account: account),
                 ),
         ),
       ];

--- a/lib/app/accounts/details/account_details_actions.dart
+++ b/lib/app/accounts/details/account_details_actions.dart
@@ -1,6 +1,5 @@
 import 'package:drift/drift.dart' as drift;
 import 'package:flutter/material.dart';
-import 'package:monekin/app/accounts/balance_correction_modal.dart';
 import 'package:monekin/app/accounts/details/account_details.dart';
 import 'package:monekin/app/transactions/form/transaction_form.page.dart';
 import 'package:monekin/core/database/services/account/account_service.dart';
@@ -44,79 +43,15 @@ abstract class AccountDetailsActions {
     }
   }
 
-  static ({
-    List<ListTileActionItem> primary,
-    List<ListTileActionItem> desktopChips,
-    List<ListTileActionItem> menu,
-  })
-  getAccountDetailsActions(
+  /// Actions shown in the account's three-dot overflow menu.
+  static List<ListTileActionItem> getAccountMenuActions(
     BuildContext context, {
     required Account account,
     bool navigateBackOnDelete = false,
   }) {
     final t = Translations.of(context);
-    final isInvestment = account.type == AccountType.investment;
 
-    final List<ListTileActionItem> primary = [];
-    final List<ListTileActionItem> desktopChips = [];
-    final List<ListTileActionItem> menu = [];
-
-    final correctBalanceAction = ListTileActionItem(
-      label: t.account.correct_balance,
-      icon: Icons.balance_rounded,
-      onClick: account.isClosed
-          ? null
-          : () => RouteUtils.showResponsiveSheet(
-              context: context,
-              builder: (context) => BalanceCorrectionModal(account: account),
-            ),
-    );
-
-    // --- Primary actions (shown as chips) ---
-
-    if (!isInvestment) {
-      primary.add(correctBalanceAction);
-
-      primary.add(
-        ListTileActionItem(
-          label: t.transfer.create,
-          icon: TransactionType.transfer.icon,
-          onClick: account.isClosed
-              ? null
-              : () => navigateToTransferOrWarn(context, fromAccount: account),
-        ),
-      );
-    } else {
-      primary.add(
-        ListTileActionItem(
-          label: t.account.add_money,
-          icon: Icons.add_rounded,
-          onClick: account.isClosed
-              ? null
-              : () => navigateToTransferOrWarn(context, toAccount: account),
-        ),
-      );
-
-      primary.add(
-        ListTileActionItem(
-          label: t.account.withdraw_money,
-          icon: Icons.remove_rounded,
-          onClick: account.isClosed
-              ? null
-              : () => navigateToTransferOrWarn(context, fromAccount: account),
-        ),
-      );
-    }
-
-    // --- Desktop-only chips (shown next to primary chips on wider screens) ---
-
-    if (isInvestment) {
-      desktopChips.add(correctBalanceAction);
-    }
-
-    // --- Menu actions (shown in three-dot popup) ---
-
-    menu.add(
+    return [
       ListTileActionItem(
         label: account.isClosed
             ? t.account.reopen_short
@@ -142,9 +77,6 @@ abstract class AccountDetailsActions {
           );
         },
       ),
-    );
-
-    menu.add(
       ListTileActionItem(
         label: t.ui_actions.delete,
         icon: Icons.delete,
@@ -157,9 +89,7 @@ abstract class AccountDetailsActions {
           );
         },
       ),
-    );
-
-    return (primary: primary, desktopChips: desktopChips, menu: menu);
+    ];
   }
 
   static void showReopenAccountDialog(BuildContext context, Account account) {

--- a/lib/app/transactions/form/state/transaction_form_controller.dart
+++ b/lib/app/transactions/form/state/transaction_form_controller.dart
@@ -340,27 +340,42 @@ class TransactionFormController extends ChangeNotifier {
       if (acc != null) fromAccount = acc;
     }
 
-    if (fromAccount == null) {
+    if (_prefillToAccount != null) {
+      transferAccount = _prefillToAccount;
+    }
+
+    // On a transfer the source can't be the same account as the destination.
+    // Drop a source that collides with a prefilled destination so it gets
+    // re-picked below with a different account.
+    if (transactionType.isTransfer &&
+        fromAccount != null &&
+        fromAccount!.id == transferAccount?.id) {
+      fromAccount = null;
+    }
+
+    if (fromAccount == null ||
+        (transactionType.isTransfer && transferAccount == null)) {
       final accounts = await AccountService.instance
           .getAccounts(
             predicate: (acc, curr) => buildDriftExpr([
               acc.isSaving.equals(false),
               acc.closingDate.isNull(),
             ]),
-            limit: transactionType.isTransfer ? 2 : 1,
+            limit: transactionType.isTransfer ? 3 : 1,
           )
           .first;
 
-      if (accounts.isNotEmpty) {
-        fromAccount = accounts[0];
-        if (transactionType.isTransfer && accounts.length > 1) {
-          transferAccount = accounts[1];
-        }
+      if (fromAccount == null) {
+        fromAccount =
+            accounts.firstWhereOrNull((a) => a.id != transferAccount?.id) ??
+            accounts.firstOrNull;
       }
-    }
 
-    if (_prefillToAccount != null) {
-      transferAccount = _prefillToAccount;
+      if (transactionType.isTransfer && transferAccount == null) {
+        transferAccount = accounts.firstWhereOrNull(
+          (a) => a.id != fromAccount?.id,
+        );
+      }
     }
 
     String? categoryIdToLoad;


### PR DESCRIPTION
## Description

The account detail screen defined a **Correct balance** action that was never rendered on any screen size — it was only added to action lists (`primary`/`desktopChips`) that the UI never consumed. This PR surfaces that action, removes the dead code around it, streamlines the account quick actions, and fixes a related bug in the transfer form.

### Changes

- Removed the never-rendered `primary`/`desktopChips` action lists from `AccountDetailsActions`. The helper now only returns the overflow-menu actions and was renamed to `getAccountMenuActions`.
- Added **Correct balance** as a quick action for non-investment accounts.
- Consolidated **Add money** / **Withdraw money** to open the transfer form (this account as destination / source respectively), removing the now-redundant standalone **New transfer** quick action — consistent with how investment/holdings accounts already behave.
- Fixed the transfer form's default-account selection so a prefilled leg is never mirrored on the other leg. Previously **Add money** could open a transfer with the same account as both source and destination.

## ✅ Checklist

- [x] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [x] I confirm that I've run the code locally and everything works as expected.

## 📸 Screenshots or Demo (if applicable)

_To be added._

## 📝 Additional Notes

- The transfer-defaulting fix lives in `TransactionFormController`, so it also covers the investment/holdings "add money" flow, which used the same `toAccount` prefill.
- `flutter analyze` is clean and `dart format` applied on the touched files.
