### PR TITLE
Fix v13 database migration failing on assets linked to transactions

### DIFF
--- a/assets/sql/migrations/v13.sql
+++ b/assets/sql/migrations/v13.sql
@@ -374,6 +374,18 @@ WHERE a.trackingMode = 'transactions'
     WHERE t.securityID = h.securityID AND t.accountID = h.accountID AND t.type = 'N'
   );
 
+-- 7e-ter. Clear leftover links to converted financial assets from
+--         non-investment transactions (types E/I/T). Pre-v13 an ordinary
+--         income or expense could be linked to a financial asset to drive its
+--         valuation. That model is gone in v13, and the asset row is about to
+--         be deleted, so we drop the dangling link to keep foreign keys valid
+--         (the transaction, its amount and category stay untouched). Type 'N'
+--         trades were already repointed to the security in step 7d.
+UPDATE transactions
+SET assetID = NULL
+WHERE type != 'N'
+  AND assetID IN (SELECT id FROM assets WHERE assetType IN ('stocks', 'funds', 'crypto'));
+
 -- 7f. Remove the converted financial assets and their valuations.
 DELETE FROM valuations
 WHERE assetId IN (SELECT id FROM assets WHERE assetType IN ('stocks', 'funds', 'crypto'));


### PR DESCRIPTION
## Description

Upgrading certain **v12** databases to **v13** failed and rolled straight back to v12, so the app kept re-attempting the migration on every launch. This PR fixes the migration so those databases upgrade cleanly with no data loss.

### Cause

v13 converts financial assets (`stocks`/`funds`/`crypto`) into securities and then **deletes** the original asset rows. It only cleared the `assetID` on investment transactions (`type = 'N'`), but pre-v13 an ordinary income/expense/transfer could also be linked to a financial asset (to drive its valuation). Those rows kept pointing at the now-deleted asset, so the post-migration `PRAGMA foreign_key_check` reported a `transactions → assets` violation. Because a violation aborts the whole version, the runner rolled v13 back and left the database on v12.

### Changes

- Added step **7e-ter** in `v13.sql`: right before the converted assets are deleted, clear any leftover `assetID` on non-`'N'` transactions that still reference a financial asset (`SET assetID = NULL`). The transaction, its amount and its category are untouched — only the obsolete asset link (a valuation model v13 no longer uses) is dropped.

## ✅ Checklist

- [x] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [x] I confirm that I've run the code locally and everything works as expected.

## 📝 Additional Notes

- Reproduced against a real exported v12 database that hit this bug: before the patch the migration rolled back with `1 foreign key violation(s) detected after migrating to v13`; after the patch it commits with `0` FK violations, all transactions preserved and both financial assets correctly turned into securities.
- Affects any v12 database where an income/expense/transfer was linked to a stock/fund/crypto asset for valuation, not just the reported one.
