### PR TITLE
Fix desktop snackbars being squeezed by the navigation sidebar

### DIFF
--- a/lib/core/presentation/helpers/snackbar.dart
+++ b/lib/core/presentation/helpers/snackbar.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:monekin/core/presentation/helpers/global_snackbar.dart';
 import 'package:monekin/core/presentation/theme.dart';
@@ -108,10 +110,19 @@ abstract class MonekinSnackbar {
 
     final context = snackbarKey.currentContext;
     final showAsToast = context != null && !AppUtils.isMobileLayout(context);
-    final screenWidth = context == null
+
+    // Snackbars are laid out by the page's Scaffold, which only spans the area
+    // at the right of the navigation sidebar, so the margins have to be
+    // measured against that area and not against the whole window.
+    final sidebarWidth =
+        (navigationSidebarKey.currentContext?.findRenderObject() as RenderBox?)
+            ?.size
+            .width ??
+        0;
+    final availableWidth = context == null
         ? 0.0
-        : MediaQuery.sizeOf(context).width;
-    final toastWidth = screenWidth > 380 ? 380.0 : screenWidth;
+        : MediaQuery.sizeOf(context).width - sidebarWidth;
+    final toastWidth = min(380.0, availableWidth - 32);
 
     return _getScaffoldMessenger(options).showSnackBar(
       SnackBar(
@@ -120,7 +131,7 @@ abstract class MonekinSnackbar {
         behavior: showAsToast ? SnackBarBehavior.floating : null,
         margin: showAsToast
             ? EdgeInsets.only(
-                left: screenWidth - toastWidth - 16,
+                left: max(0, availableWidth - toastWidth - 16),
                 right: 16,
                 bottom: 16,
               )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ publish_to: 'none'
 # The X represents the major releases, and can be up to infinity. Never start by a zero
 # The Y represents the minor releases, and can be up to 99. Always start by a zero
 # The Z represents the patch releases, and can be up to 999. Always start by a zero
-version: 10.0.1+1000001
+version: 10.0.2+1000002
 
 environment:
   flutter: 3.44.1

--- a/windows/exe-builder.iss
+++ b/windows/exe-builder.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 ; Non-commercial use only
 #define MyAppName "Monekin"
-#define MyAppVersion "10.0.1"
+#define MyAppVersion "10.0.2"
 #define MyAppPublisher "Lozin Tech."
 #define MyAppURL "https://github.com/enrique-lozano/Monekin"
 #define MyAppExeName "monekin.exe"


### PR DESCRIPTION
## Description

On desktop layouts the floating snackbar was rendered far narrower than intended, wrapping its text character by character. This PR makes the toast use its intended width again.

### Cause

`MonekinSnackbar.openSnackbar` positioned the toast with a hand-computed `margin`, taking the screen width from `snackbarKey.currentContext` — the `MaterialApp`'s `ScaffoldMessenger`, whose `MediaQuery` spans the **whole window**. The snackbar itself, however, is laid out by the route's `Scaffold`, which sits inside the `Expanded` next to `AppNavigationSidebar` and is therefore `windowWidth - sidebarWidth` wide.

The left margin overshot by exactly the sidebar width, collapsing the toast to a constant `380 - sidebarWidth`: **140px** at the `xl` breakpoint (240px sidebar) and 272px between `md` and `xl` (108px sidebar), no matter how wide the window was.

### Changes

- `openSnackbar` now measures the available space as `windowWidth - sidebarWidth` and derives both the toast width and the left margin from it, so the toast is a real 380px pinned to the bottom-right corner of the content area.
- The sidebar width is read from the already rendered widget through `navigationSidebarKey`, instead of recomputing it with `getNavigationSidebarWidth`. That way it also stays correct where the sidebar isn't in the tree at all (the intro/onboarding flow), since the key has no context there and the width falls back to `0`.
- Added `min`/`max` guards so a content area narrower than `380 + 32` shrinks the toast instead of overflowing or producing a negative margin.

## ✅ Checklist

- [x] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [x] I confirm that I've run the code locally and everything works as expected.

## 📸 Screenshots or Demo (if applicable)

<img width="1445" height="946" alt="image" src="https://github.com/user-attachments/assets/83ac1834-b8da-434f-b4ed-f66b13a9633a" />

## 📝 Additional Notes

- Mobile layouts are unaffected: `showAsToast` is `false` there, so neither the margin nor the floating behaviour is applied.
- The top-of-screen `GlobalSnackbar` path never had this problem, as it is stacked next to the navigator and stretches to the content width on its own.
- `flutter analyze` is clean and `dart format` applied on the touched files.
