### PR TITLE
Net worth counting lent debts as a liability instead of a receivable

### DIFF
--- a/docs/BALANCE_FORMULAS.md
+++ b/docs/BALANCE_FORMULAS.md
@@ -145,7 +145,7 @@ Optional transaction filters can be passed through for stats consistency (`Trans
 
 ### 5.2 Liabilities (debts)
 
-**Debts** is the sum of each debt’s **remaining** balance, converted to the preferred currency. Conversion uses exchange rates as of the same date $t$ used on the chart point; remaining amounts follow the live debt ledger (same behaviour as the net-worth chart).
+**Debts** is the sum of each debt’s **remaining** balance, converted to the preferred currency: debts the user **borrowed** add to the total, while debts the user **lent** out are receivables and subtract from it ($\text{Debts}(t) = \sum \text{Remaining}(\text{borrowed}) - \sum \text{Remaining}(\text{lent})$). Conversion uses exchange rates as of the same date $t$ used on the chart point; remaining amounts follow the live debt ledger (same behaviour as the net-worth chart).
 
 > **Implementation:** `NetWorthService.getTotalDebtsInPreferredCurrency(exchangeRateAsOf: t)`.
 

--- a/lib/core/database/services/net_worth/net_worth_service.dart
+++ b/lib/core/database/services/net_worth/net_worth_service.dart
@@ -5,6 +5,7 @@ import 'package:monekin/core/database/services/debts/debt_service.dart';
 import 'package:monekin/core/database/services/exchange-rate/exchange_rate_service.dart';
 import 'package:monekin/core/models/currency/currency.dart';
 import 'package:monekin/core/models/debt/debt.dart';
+import 'package:monekin/core/models/debt/debt_direction.enum.dart';
 import 'package:monekin/core/presentation/widgets/transaction_filter/transaction_filter_set.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -38,6 +39,9 @@ class NetWorthService {
 
   /// Sum of each debt’s **remaining** balance, converted to the preferred currency.
   ///
+  /// Debts the user borrowed add to the total; debts the user lent out are
+  /// receivables, so they subtract from it (net = borrowed − lent).
+  ///
   /// [exchangeRateAsOf] is used only for currency conversion. Remaining amounts
   /// follow [DebtService.getDebtRemainingAmount] (current ledger), matching
   /// [NetWorthEvolutionCard] behaviour.
@@ -61,13 +65,19 @@ class NetWorthService {
         return DebtService.instance.getDebtRemainingAmount(debt).switchMap((
           double remaining,
         ) {
+          // Money the user lent out is owed *to* them (a receivable), so it
+          // must offset what's borrowed rather than add to it.
+          final signedRemaining = debt.type == DebtDirection.lent
+              ? -remaining
+              : remaining;
+
           if (debt.currency.code == pref.code) {
-            return Stream.value(remaining);
+            return Stream.value(signedRemaining);
           }
           return ExchangeRateService.instance
               .calculateExchangeRateToPreferredCurrency(
                 fromCurrency: debt.currency.code,
-                amount: remaining,
+                amount: signedRemaining,
                 date: asOf,
               );
         });


### PR DESCRIPTION
## Description

The "Debts" figure in the net-worth stats (and the net-worth evolution chart) summed every debt's remaining balance the same way, no matter its direction. This PR makes money lent out offset money borrowed instead of stacking on top of it.

### Cause

`NetWorthService.getTotalDebtsInPreferredCurrency` folded each debt's `getDebtRemainingAmount()` with a plain `+`. That method always returns a non-negative magnitude (useful for progress bars on the debt details/list pages), so the direction (`DebtDirection.lent` vs `borrowed`) was lost before the sum. A `lent` debt is money someone else owes the user — a receivable, i.e. an asset — but it was being treated as a liability exactly like a `borrowed` debt. With one of each for the same amount, "Debts" showed double the amount instead of netting to zero, and net worth was penalized by the lent amount even though nothing had actually left the user's net worth (only its liquidity).

### Changes

- `NetWorthService.getTotalDebtsInPreferredCurrency`: negate a debt's remaining amount when `debt.type == DebtDirection.lent` before summing, so the total is now `Σ borrowed − Σ lent`.
- Updated `docs/BALANCE_FORMULAS.md` §5.2 to document the signed formula.

`NetWorthEvolutionCard` and every other net-worth consumer already go through this method, so no other call site needed changes. The per-debt progress displays (`debt_details_page.dart`, `debts_page.dart`, `debt_list.dart`, `asset_details_page.dart`) call `getDebtRemainingAmount()` directly and are unaffected, since the unsigned magnitude is what they need there.

## ✅ Checklist

- [x] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [x] I confirm that I've run the code locally and everything works as expected.

## 🔗 Related Issues

- Fixes #515

## 📝 Additional Notes

- `flutter analyze` is clean on the touched files.
- No DB migration or schema change needed; this is a pure calculation fix.
