### PR TITLE
Fix v13 migration failing on legacy camelCase asset types

### DIFF
--- a/assets/sql/migrations/v13.sql
+++ b/assets/sql/migrations/v13.sql
@@ -269,13 +269,7 @@ FROM assets a
 WHERE a.assetType IN ('stocks', 'funds', 'crypto');
 
 -- 7b. Valuations of those assets become price-history points. Dates are
---     normalized to date-only (one observation per calendar day). The app
---     keeps at most one valuation per asset per day, but it enforces that in
---     Dart (not with a DB constraint on DATE(date)), so a dirty database could
---     still hold two valuations that collapse to the same calendar day and
---     violate the unique index on securityPrices(securityID, date). INSERT OR
---     IGNORE plus the newest-first ordering keeps the latest value of the day
---     and drops the rest instead of aborting the whole migration.
+--     normalized to date-only (one observation per calendar day).
 INSERT OR IGNORE INTO securityPrices (id, securityID, date, price)
 SELECT 'sph_' || v.id, 'sec_' || v.assetId, DATE(v.date), v.value
 FROM valuations v

--- a/assets/sql/migrations/v13.sql
+++ b/assets/sql/migrations/v13.sql
@@ -269,12 +269,19 @@ FROM assets a
 WHERE a.assetType IN ('stocks', 'funds', 'crypto');
 
 -- 7b. Valuations of those assets become price-history points. Dates are
---     normalized to date-only (one observation per calendar day).
-INSERT INTO securityPrices (id, securityID, date, price)
+--     normalized to date-only (one observation per calendar day). The app
+--     keeps at most one valuation per asset per day, but it enforces that in
+--     Dart (not with a DB constraint on DATE(date)), so a dirty database could
+--     still hold two valuations that collapse to the same calendar day and
+--     violate the unique index on securityPrices(securityID, date). INSERT OR
+--     IGNORE plus the newest-first ordering keeps the latest value of the day
+--     and drops the rest instead of aborting the whole migration.
+INSERT OR IGNORE INTO securityPrices (id, securityID, date, price)
 SELECT 'sph_' || v.id, 'sec_' || v.assetId, DATE(v.date), v.value
 FROM valuations v
 INNER JOIN assets a ON a.id = v.assetId
-WHERE a.assetType IN ('stocks', 'funds', 'crypto');
+WHERE a.assetType IN ('stocks', 'funds', 'crypto')
+ORDER BY v.date DESC, v.id DESC;
 
 -- 7b-bis. Financial assets without valuations get a single seed point
 --         (date-only).
@@ -413,8 +420,27 @@ CREATE TABLE assets_new (
     linkedDebtId TEXT REFERENCES debts(id) ON DELETE SET NULL ON UPDATE CASCADE
 );
 
+-- Normalize assetType to the new physical-only snake_case enum. Legacy rows
+-- can hold the old camelCase enum name (e.g. 'realEstate'): the v12 migration
+-- added `assetType` WITHOUT a CHECK, so unnormalized values could slip in
+-- (some builds/backups stored the Dart enum name instead of its databaseValue).
+-- Any value we do not recognize falls back to 'other' so the CHECK on
+-- `assets_new` can never abort the whole migration. Financial types were
+-- already converted and removed in Step 7, so they never reach here.
 INSERT INTO assets_new (id, name, description, currencyId, initialValue, creationDate, assetType, linkedDebtId)
-SELECT id, name, description, currencyId, initialValue, creationDate, assetType, NULL
+SELECT id, name, description, currencyId, initialValue, creationDate,
+    CASE assetType
+        WHEN 'real_estate' THEN 'real_estate'
+        WHEN 'realEstate' THEN 'real_estate'
+        WHEN 'precious_metal' THEN 'precious_metal'
+        WHEN 'preciousMetal' THEN 'precious_metal'
+        WHEN 'jewelry_art' THEN 'jewelry_art'
+        WHEN 'jewelryArt' THEN 'jewelry_art'
+        WHEN 'vehicle' THEN 'vehicle'
+        WHEN 'other' THEN 'other'
+        ELSE 'other'
+    END,
+    NULL
 FROM assets;
 
 DROP TABLE assets;

--- a/test/migrations/v13_migration_test.dart
+++ b/test/migrations/v13_migration_test.dart
@@ -17,7 +17,13 @@ List<String> splitSQLStatements(String sqliteStr) {
 /// Applies `assets/sql/migrations/v13.sql` to a copy of the v12 sample DB the
 /// same way the app does (statement split, FK pragmas stripped, FK off around
 /// the batch) and returns the migrated, open database.
-Database migrateSample() {
+Database migrateSample() => migrateSampleMutated(null);
+
+/// Same as [migrateSample], but runs [mutate] on the copied v12 database
+/// *before* applying the migration. Lets a test inject legacy/dirty rows (e.g.
+/// an asset stored with the old camelCase enum name) and assert the migration
+/// still succeeds.
+Database migrateSampleMutated(void Function(Database db)? mutate) {
   final sample = File('assets/sql/samples/v12_sample.db');
   expect(sample.existsSync(), isTrue, reason: 'v12 sample DB missing');
 
@@ -32,6 +38,8 @@ Database migrateSample() {
 
   final db = sqlite3.open(tmp.path);
   addTearDown(db.dispose);
+
+  if (mutate != null) mutate(db);
 
   final statements =
       splitSQLStatements(
@@ -54,6 +62,19 @@ Database migrateSample() {
 
   expect(fkViolations, isEmpty, reason: 'FK violations after migrating to v13');
   return db;
+}
+
+/// Inserts a physical asset carrying the given raw `assetType` string into the
+/// copied v12 DB (reusing an existing currency), so tests can feed the migration
+/// legacy enum encodings.
+void insertLegacyAsset(Database db, String id, String assetType) {
+  db.execute(
+    '''
+    INSERT INTO assets (id, name, description, currencyId, initialValue, creationDate, assetType, linkedAccountID)
+    VALUES (?, ?, NULL, (SELECT code FROM currencies LIMIT 1), 1000, '2024-01-01', ?, NULL)
+    ''',
+    [id, 'Legacy $id', assetType],
+  );
 }
 
 void main() {
@@ -306,6 +327,73 @@ void main() {
       offenders,
       isEmpty,
       reason: 'comment lines must not contain ";":\n${offenders.join('\n')}',
+    );
+  });
+
+  test('legacy camelCase assetType values migrate to the snake_case enum', () {
+    // v12 added `assets.assetType` WITHOUT a CHECK, so real databases carry the
+    // old Dart enum name ('realEstate', ...) instead of its databaseValue
+    // ('real_estate', ...). Copying it verbatim used to fail the CHECK on the
+    // rebuilt `assets` table and roll the whole migration back to v12.
+    final db = migrateSampleMutated((db) {
+      insertLegacyAsset(db, 'legacy_re', 'realEstate');
+      insertLegacyAsset(db, 'legacy_pm', 'preciousMetal');
+      insertLegacyAsset(db, 'legacy_ja', 'jewelryArt');
+      insertLegacyAsset(db, 'legacy_ve', 'vehicle');
+    });
+
+    String typeOf(String id) => db.select(
+      'SELECT assetType FROM assets WHERE id = ?',
+      [id],
+    ).first['assetType'] as String;
+
+    expect(typeOf('legacy_re'), 'real_estate');
+    expect(typeOf('legacy_pm'), 'precious_metal');
+    expect(typeOf('legacy_ja'), 'jewelry_art');
+    expect(typeOf('legacy_ve'), 'vehicle');
+  });
+
+  test('an unrecognized assetType falls back to "other" instead of aborting', () {
+    final db = migrateSampleMutated(
+      (db) => insertLegacyAsset(db, 'legacy_unknown', 'someFutureType'),
+    );
+
+    final type = db.select(
+      'SELECT assetType FROM assets WHERE id = ?',
+      ['legacy_unknown'],
+    ).first['assetType'] as String;
+
+    expect(type, 'other');
+  });
+
+  test('two same-day valuations of a financial asset collapse to one price', () {
+    // The app keeps one valuation per day in Dart, not via a DB constraint on
+    // DATE(date), so a dirty DB can hold two valuations that collapse to the
+    // same calendar day. Without dedup they'd violate the unique index on
+    // securityPrices(securityID, date) and abort the migration.
+    final db = migrateSampleMutated((db) {
+      db.execute('''
+        INSERT INTO assets (id, name, description, currencyId, initialValue, creationDate, assetType, linkedAccountID)
+        VALUES ('dirty_fin', 'Dirty Fund', NULL, (SELECT code FROM currencies LIMIT 1), 100, '2024-01-01', 'funds', NULL)
+      ''');
+      db.execute(
+        "INSERT INTO valuations (id, assetId, date, value) VALUES ('dv_early', 'dirty_fin', '2024-03-10T09:00:00.000', 110)",
+      );
+      db.execute(
+        "INSERT INTO valuations (id, assetId, date, value) VALUES ('dv_late', 'dirty_fin', '2024-03-10T18:00:00.000', 120)",
+      );
+    });
+
+    final prices = db.select(
+      "SELECT date, price FROM securityPrices WHERE securityID = 'sec_dirty_fin'",
+    );
+
+    expect(prices.length, 1, reason: 'same-day valuations collapse to one row');
+    expect(prices.first['date'], '2024-03-10');
+    expect(
+      (prices.first['price'] as num).toDouble(),
+      120,
+      reason: 'the latest value of the day wins',
     );
   });
 }


### PR DESCRIPTION
## Description

Another **v12 → v13** migration failure reported by a user: the upgrade aborted and rolled back to v12, so the app kept retrying it on every launch. This is a **different** root cause from the previously-fixed dangling-asset-link bug. This PR fixes it and hardens a second, latent failure in the same migration.

### Cause

The v12 migration added `assets.assetType` **without a `CHECK`** constraint:

```sql
ALTER TABLE assets ADD COLUMN assetType TEXT NOT NULL DEFAULT 'other';
```

So real databases can hold the **old camelCase Dart enum name** (`realEstate`, `preciousMetal`, `jewelryArt`) instead of the current snake_case `databaseValue` (`real_estate`, ...). v13 rebuilds `assets` with a CHECK that only allows the snake_case physical types and copied `assetType` **verbatim**, so any such row failed the `CHECK` and the whole v13 transaction was rolled back. The reported database had a `realEstate` property, so it never migrated. Every other enum column was safe because it already had a `CHECK` back in v12 — `assetType` was the only unconstrained one.

### Changes

- **Step 8 (`assets` rebuild):** remap `assetType` through a `CASE` that accepts both the legacy camelCase names and the current snake_case values, and **falls back to `'other'`** for anything unrecognized, so the `CHECK` can never abort the migration again.
- **Step 7b (`securityPrices`):** hardened against a latent crash. The app keeps one valuation per asset per day, but enforces it in Dart — not with a DB constraint on `DATE(date)` — so a dirty database could hold two same-day valuations that collide on the unique index `securityPrices(securityID, date)`. Switched to `INSERT OR IGNORE` with newest-first ordering, which keeps the latest value of the day and drops the rest instead of failing.
- **Tests:** added regression tests that feed the migration legacy camelCase types, an unknown type (→ `other`), and a same-day valuation collision.

## ✅ Checklist

- [x] I've read and understand the [Code Contributions Guide](https://github.com/enrique-lozano/Monekin/blob/main/docs/CODE_CONTRIBUTING.md).
- [x] I confirm that I've run the code locally and everything works as expected.

## 📝 Additional Notes

- Reproduced against the reported v12 database: before the patch it failed with `CHECK constraint failed: assetType IN (...)`; after the patch it commits cleanly (`Property` → `real_estate`), 0 FK violations, all 3927 transactions and both accounts/assets preserved.
- `flutter test test/migrations/v13_migration_test.dart` → **14/14 passing** (3 new).
- The same-day valuation dedup is defensive: clean data already can't hit it, but it removes a whole class of "dirty DB" migration crashes.
